### PR TITLE
[office] fix the cover page showing wrong content

### DIFF
--- a/qml/CoverPage.qml
+++ b/qml/CoverPage.qml
@@ -82,6 +82,7 @@ CoverBackground {
         width: isPortrait ? parent.width : parent.height
         height: isPortrait ? parent.height : parent.width
         rotation: isPortrait ? 0 : 90
+        visible: window.documentItem != null
 
         Image {
             id: previewImage


### PR DESCRIPTION
When going back to the main view after looking at a document the cover used to show the now closed document over the documents list.
