### PR TITLE
Proposed solution to solve issue #10

### DIFF
--- a/models/documentlistmodel.h
+++ b/models/documentlistmodel.h
@@ -58,7 +58,9 @@ public:
     virtual int rowCount(const QModelIndex& parent) const;
     virtual QHash< int, QByteArray > roleNames() const;
 
+    void setAllItemsDirty(bool status);
     void addItem(QString name, QString path, QString type, int size, QDateTime lastRead, QString mimeType);
+    void removeItemsDirty();
     void removeAt(int index);
     void clear();
 

--- a/models/trackerdocumentprovider.cpp
+++ b/models/trackerdocumentprovider.cpp
@@ -113,9 +113,13 @@ void TrackerDocumentProvider::searchFinished()
     QSparqlResult* r = qobject_cast<QSparqlResult*>(sender());
     if(!r->hasError())
     {
-        d->model->clear();
+        // d->model->clear();
+        // Mark all current entries in the model dirty.
+        d->model->setAllItemsDirty(true);
         while(r->next())
         {
+            // This will remove the dirty flag for already
+            // existing entries.
             d->model->addItem(
                 r->binding(0).value().toString(),
                 r->binding(1).value().toString(),
@@ -125,6 +129,8 @@ void TrackerDocumentProvider::searchFinished()
                 r->binding(4).value().toString()
             );
         }
+        // Remove all entries with the dirty mark.
+        d->model->removeItemsDirty();
     }
 
     emit countChanged();


### PR DESCRIPTION
The purpose of these two commits is to avoid to call clear() on the model when tracker signal a change in the list of documents.

To do this, the searchFinished() function has been modified to update the current list model instead of clearing it and rebuild it. There are three things to do :
* add new entries (already done by addItem()) ;
* update already existing entries (think new document of a different type, replacing an old one) ;
* remove entries not in tracker list anymore.
The second point is changed in addItem() to update when finding an already existing entry. The third is done via a new boolean in the structure DocumentListModelEntry.

Quickly tested on my device, it solve the issue #10 and avoid in addition the flicking of the list when a document is removed / added.