### PR TITLE
Notify user on broken PDF files

### DIFF
--- a/pdf/pdfdocument.cpp
+++ b/pdf/pdfdocument.cpp
@@ -76,6 +76,11 @@ bool PDFDocument::isLoaded() const
     return d->thread->isLoaded();
 }
 
+bool PDFDocument::isFailed() const
+{
+    return d->thread->isFailed();
+}
+
 PDFDocument::LinkMap PDFDocument::linkTargets() const
 {
     return d->thread->linkTargets();

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -40,6 +40,7 @@ class PDFDocument : public QObject, public QQmlParserStatus
     Q_PROPERTY(int pageCount READ pageCount NOTIFY pageCountChanged)
     Q_PROPERTY(QObject* tocModel READ tocModel NOTIFY tocModelChanged)
     Q_PROPERTY(bool loaded READ isLoaded NOTIFY documentLoaded)
+    Q_PROPERTY(bool failure READ isFailed NOTIFY documentFailed)
 
     Q_INTERFACES(QQmlParserStatus)
 
@@ -57,6 +58,7 @@ public:
     LinkMap linkTargets() const;
 
     bool isLoaded() const;
+    bool isFailed() const;
 
     virtual void classBegin();
     virtual void componentComplete();
@@ -75,6 +77,7 @@ Q_SIGNALS:
     void tocModelChanged();
 
     void documentLoaded();
+    void documentFailed();
     void pageFinished( int index, QSGTexture *page );
     void pageSizesFinished(const QList< QSizeF >& heights);
 

--- a/pdf/pdfjob.cpp
+++ b/pdf/pdfjob.cpp
@@ -29,8 +29,10 @@ LoadDocumentJob::LoadDocumentJob(const QString& source)
 void LoadDocumentJob::run()
 {
     m_document = Poppler::Document::load(m_source);
-    m_document->setRenderHint( Poppler::Document::Antialiasing, true );
-    m_document->setRenderHint( Poppler::Document::TextAntialiasing, true );
+    if (m_document) {
+        m_document->setRenderHint( Poppler::Document::Antialiasing, true );
+        m_document->setRenderHint( Poppler::Document::TextAntialiasing, true );
+    }
 }
 
 RenderPageJob::RenderPageJob(int index, uint width, QQuickWindow *window)

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -38,6 +38,7 @@ public:
     int pageCount() const;
     QObject* tocModel() const;
     bool isLoaded() const;
+    bool isFailed() const;
     QMultiMap< int, QPair< QRectF, QUrl > > linkTargets() const;
 
     void queueJob( PDFJob* job );

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Office.PDF 1.0 as PDF
+import org.nemomobile.notifications 1.0
 
 DocumentPage {
     id: base;
@@ -44,6 +45,11 @@ DocumentPage {
     PDF.Document {
         id: pdfDocument;
         source: base.path;
+        onDocumentLoaded: if (failure) {
+            pageStack.completeAnimation();
+            pageStack.pop();
+            notification.publish();
+        }
     }
 
     busy: !pdfDocument.loaded;
@@ -55,4 +61,12 @@ DocumentPage {
         interval: 5000;
         onTriggered: linkArea.sourceSize = Qt.size( base.width, pdfCanvas.height );
     }
+
+    Notification {
+        id: notification;
+        //% "Cannot open PDF file"
+        previewBody: qsTrId("sailfish-office-me-broken-pdf-desc");
+        //% "Broken file"
+        previewSummary: qsTrId("sailfish-office-me-broken-pdf-summary");
+    }    
 }


### PR DESCRIPTION
Proposed patches to avoid crashes when tapping on a broken PDF file (issue #21).

I've :
- protected all calls to attributes of Poppler::Document when it is a null pointer because of loading failure at pdfjob.cpp:31.
- added a flag in PdfRenderThread that becomes true when file loading results in a null pointer and expose it read only in PdfDocument.
- used this flag in QML to return to document list when tapping on a broken PDF file and notify the user.

What do you think ? I don't like much the fact that the page for the PDF file is pushed and then popped immediately, but I don't know what to show otherwise. On the other side, that would be nice to still have the drawer at hand even for broken PDF files, because we may want to forward them by email for investigation…