### PR TITLE
[sailfish-office] Add the ability to unlock password encrypted PDF documents

### DIFF
--- a/pdf/pdfcanvas.cpp
+++ b/pdf/pdfcanvas.cpp
@@ -153,6 +153,7 @@ void PDFCanvas::setDocument(PDFDocument* doc)
         connect( d->document, &PDFDocument::documentLoaded, this, &PDFCanvas::documentLoaded );
         connect( d->document, &PDFDocument::pageFinished, this, &PDFCanvas::pageFinished );
         connect( d->document, &PDFDocument::pageSizesFinished, this, &PDFCanvas::pageSizesFinished );
+        connect( d->document, &PDFDocument::documentLocked, this, &PDFCanvas::documentLoaded );
 
         if( d->document->isLoaded() )
             documentLoaded();

--- a/pdf/pdfdocument.cpp
+++ b/pdf/pdfdocument.cpp
@@ -43,6 +43,7 @@ PDFDocument::PDFDocument(QObject* parent)
     d->thread = new PDFRenderThread{ this };
     connect( d->thread, &PDFRenderThread::loadFinished, this, &PDFDocument::documentLoaded );
     connect( d->thread, &PDFRenderThread::loadFinished, this, &PDFDocument::pageCountChanged );
+    connect( d->thread, &PDFRenderThread::loadFinished, this, &PDFDocument::loadFinished );
     connect( d->thread, &PDFRenderThread::jobFinished, this, &PDFDocument::jobFinished );
 }
 
@@ -151,6 +152,11 @@ void PDFDocument::requestPageSizes()
     d->thread->queueJob( job );
 }
 
+void PDFDocument::loadFinished()
+{
+  if (d->thread->isFailed())
+    emit documentFailed();
+}
 void PDFDocument::jobFinished(PDFJob* job)
 {
     switch(job->type()) {

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -41,6 +41,7 @@ class PDFDocument : public QObject, public QQmlParserStatus
     Q_PROPERTY(QObject* tocModel READ tocModel NOTIFY tocModelChanged)
     Q_PROPERTY(bool loaded READ isLoaded NOTIFY documentLoaded)
     Q_PROPERTY(bool failure READ isFailed NOTIFY documentFailed)
+    Q_PROPERTY(bool locked READ isLocked NOTIFY documentLocked)
 
     Q_INTERFACES(QQmlParserStatus)
 
@@ -59,12 +60,14 @@ public:
 
     bool isLoaded() const;
     bool isFailed() const;
+    bool isLocked() const;
 
     virtual void classBegin();
     virtual void componentComplete();
 
 public Q_SLOTS:
     void setSource(const QString& source);
+    void requestUnLock( const QString& password );
     void requestPage( int index, int size, QQuickWindow *window );
     void prioritizeRequest( int index, int size);
     void cancelPageRequest(int index);
@@ -79,6 +82,7 @@ Q_SIGNALS:
 
     void documentLoaded();
     void documentFailed();
+    void documentLocked();
     void pageFinished( int index, QSGTexture *page );
     void pageSizesFinished(const QList< QSizeF >& heights);
 

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -69,6 +69,7 @@ public Q_SLOTS:
     void prioritizeRequest( int index, int size);
     void cancelPageRequest(int index);
     void requestPageSizes();
+    void loadFinished();
     void jobFinished(PDFJob* job);
 
 Q_SIGNALS:

--- a/pdf/pdfjob.cpp
+++ b/pdf/pdfjob.cpp
@@ -35,6 +35,20 @@ void LoadDocumentJob::run()
     }
 }
 
+UnLockDocumentJob::UnLockDocumentJob(const QString& password)
+    : PDFJob(PDFJob::UnLockDocumentJob), m_password(password)
+{
+
+}
+
+void UnLockDocumentJob::run()
+{
+    Q_ASSERT(m_document);
+
+    if (m_document->isLocked())
+        m_document->unlock( m_password.toUtf8(), m_password.toUtf8() );
+}
+
 RenderPageJob::RenderPageJob(int index, uint width, QQuickWindow *window)
     : PDFJob{ PDFJob::RenderPageJob }, m_index{ index }, m_page{ 0 }, m_window{ window }, m_width{ width }
 {

--- a/pdf/pdfjob.h
+++ b/pdf/pdfjob.h
@@ -35,6 +35,7 @@ class PDFJob : public QObject
 public:
     enum JobType {
         LoadDocumentJob,
+        UnLockDocumentJob,
         RenderPageJob,
         PageSizesJob,
     };
@@ -64,6 +65,18 @@ public:
 
 private:
     QString m_source;
+};
+
+class UnLockDocumentJob : public PDFJob
+{
+    Q_OBJECT
+public:
+    UnLockDocumentJob( const QString& password );
+
+    virtual void run();
+
+private:
+    QString m_password;
 };
 
 class RenderPageJob : public PDFJob

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -39,6 +39,7 @@ public:
     QObject* tocModel() const;
     bool isLoaded() const;
     bool isFailed() const;
+    bool isLocked() const;
     QMultiMap< int, QPair< QRectF, QUrl > > linkTargets() const;
 
     void queueJob( PDFJob* job );

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -39,23 +39,46 @@ DocumentPage {
         document: pdfDocument;
 
         onClicked: base.open = !base.open;
-    }
 
-    ViewPlaceholder {
-        flickable: view;
-        enabled: pdfDocument.failure;
-        //% "Broken file"
-        text: qsTrId("sailfish-office-me-broken-pdf-summary");
-        //% "Cannot open PDF file"
-        hintText: qsTrId("sailfish-office-me-broken-pdf-desc");
-        MouseArea {
-            anchors.fill: parent
-            onClicked: base.open = !base.open;
+        ViewPlaceholder {
+            enabled: pdfDocument.failure || pdfDocument.locked
+            y: (flickable ? flickable.originY : 0) + (base.height - height - (passwd.visible ? passwd.height : 0)) / 2
+            //% "Broken file"
+            text: pdfDocument.failure ? qsTrId("sailfish-office-me-broken-pdf") :
+            //%  "Locked file"
+            qsTrId("sailfish-office-me-locked-pdf")
+            //% "Cannot read the PDF document"
+            hintText: pdfDocument.failure ? qsTrId("sailfish-office-me-broken-pdf-hint") :
+            //% "Enter password to unlock"
+            qsTrId("sailfish-office-me-locked-pdf-hint")
+            MouseArea {
+                anchors.fill: parent
+                onClicked: base.open = !base.open
+            }
+            TextField {
+                id: passwd
+                visible: pdfDocument.locked
+                width: parent.width - Theme.paddingLarge
+                anchors.top: parent.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                //% "password"
+                label: qsTrId("sailfish-office-la-password")
+                placeholderText: label
+
+                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+                echoMode: TextInput.Password
+                EnterKey.enabled: text
+                EnterKey.onClicked: {
+                    focus = false
+                    pdfDocument.requestUnLock(text)
+                    text = ""
+                }
+
+                onFocusChanged: if (focus) base.open = false
+            }
         }
-        /*Button {
-            anchors.top: parent.bottom;
-            text: "Unlock"
-        }*/
+
     }
 
     PDF.Document {

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -19,7 +19,6 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Office.PDF 1.0 as PDF
-import org.nemomobile.notifications 1.0
 
 DocumentPage {
     id: base;
@@ -42,17 +41,29 @@ DocumentPage {
         onClicked: base.open = !base.open;
     }
 
+    ViewPlaceholder {
+        flickable: view;
+        enabled: pdfDocument.failure;
+        //% "Broken file"
+        text: qsTrId("sailfish-office-me-broken-pdf-summary");
+        //% "Cannot open PDF file"
+        hintText: qsTrId("sailfish-office-me-broken-pdf-desc");
+        MouseArea {
+            anchors.fill: parent
+            onClicked: base.open = !base.open;
+        }
+        /*Button {
+            anchors.top: parent.bottom;
+            text: "Unlock"
+        }*/
+    }
+
     PDF.Document {
         id: pdfDocument;
         source: base.path;
-        onDocumentLoaded: if (failure) {
-            pageStack.completeAnimation();
-            pageStack.pop();
-            notification.publish();
-        }
     }
 
-    busy: !pdfDocument.loaded;
+    busy: !pdfDocument.loaded && !pdfDocument.failure;
     source: pdfDocument.source;
     indexCount: pdfDocument.pageCount;
 
@@ -61,12 +72,4 @@ DocumentPage {
         interval: 5000;
         onTriggered: linkArea.sourceSize = Qt.size( base.width, pdfCanvas.height );
     }
-
-    Notification {
-        id: notification;
-        //% "Cannot open PDF file"
-        previewBody: qsTrId("sailfish-office-me-broken-pdf-desc");
-        //% "Broken file"
-        previewSummary: qsTrId("sailfish-office-me-broken-pdf-summary");
-    }    
 }


### PR DESCRIPTION
I've wrapped thePoppler::Document::unlock() method in Pdf::Document (through a call in background) and add a requestUnLock() method for Pdf::Document objects.

The UI has been updated in accordance to be able to enter password for encrypted PDF files. This is done through a ViewPlaceholder in the PDFView object.

The previously introduced notification for broken PDF has been removed in favour of this new ViewPlaceholder.

This pull request partially address issue #1 for PDF documents.