### PR TITLE
[sailfish-office] Filter the document list with a search field

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(sailfishoffice_SRCS
     main.cpp
     dbusadaptor.cpp
     sailfishapplication.cpp
+    models/filtermodel.cpp
     models/documentlistmodel.cpp
     models/documentproviderlistmodel.cpp
     models/documentproviderplugin.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(sailfishoffice_SRCS
 
 set(sailfishoffice_QML_SRCS
     qml/CoverPage.qml
+    qml/SearchPageHeader.qml
     qml/FileListPage.qml
     qml/Main.qml
     qml/StartPage.qml

--- a/models/filtermodel.cpp
+++ b/models/filtermodel.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "filtermodel.h"
+
+#include "documentlistmodel.h"
+
+FilterModel::FilterModel(QObject* parent)
+    : QSortFilterProxyModel(parent)
+{
+  this->setFilterRole(DocumentListModel::Roles::FileNameRole);
+}
+
+FilterModel::~FilterModel()
+{
+}
+
+void FilterModel::setSourceModel(DocumentListModel *model)
+{
+  QSortFilterProxyModel::setSourceModel(static_cast<QAbstractItemModel*>(model));
+}
+
+DocumentListModel* FilterModel::sourceModel() const
+{
+  return static_cast<DocumentListModel*>(QSortFilterProxyModel::sourceModel());
+}

--- a/models/filtermodel.h
+++ b/models/filtermodel.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef FILTERMODEL_H
+#define FILTERMODEL_H
+
+#include <QSortFilterProxyModel>
+
+#include "documentlistmodel.h"
+
+class FilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+    Q_PROPERTY(DocumentListModel *sourceModel READ sourceModel WRITE setSourceModel NOTIFY sourceModelChanged)
+public:
+    FilterModel(QObject* parent = 0);
+    ~FilterModel();
+
+public:
+    DocumentListModel* sourceModel() const;
+
+public Q_SLOTS:
+    void setSourceModel(DocumentListModel *model);
+
+Q_SIGNALS:
+    void sourceModelChanged();
+};
+
+#endif // FILTERMODEL_H

--- a/qml/FileListPage.qml
+++ b/qml/FileListPage.qml
@@ -23,17 +23,23 @@ import Sailfish.Office.Files 1.0
 
 Page {
     id: page
-    property alias model: listView.model;
+    property alias model: filteredModel.sourceModel;
     property string title: "";
     property QtObject provider;
 
     allowedOrientations: Orientation.All;
+
+    FilterModel {
+        id: filteredModel
+        filterRegExp: RegExp("")
+    }
 
     SilicaListView {
         id: listView;
         anchors.fill: parent
 
         currentIndex: -1;
+        model: filteredModel
 
         children: ScrollDecorator { }
         header: PageHeader {

--- a/qml/FileListPage.qml
+++ b/qml/FileListPage.qml
@@ -25,13 +25,14 @@ Page {
     id: page
     property alias model: filteredModel.sourceModel;
     property string title: "";
+    property string searchText: "";
     property QtObject provider;
 
     allowedOrientations: Orientation.All;
 
     FilterModel {
         id: filteredModel
-        filterRegExp: RegExp("")
+        filterRegExp: RegExp(searchText, "i")
     }
 
     SilicaListView {
@@ -42,13 +43,37 @@ Page {
         model: filteredModel
 
         children: ScrollDecorator { }
-        header: PageHeader {
+        header: SearchPageHeader {
+            id: header
+            width: parent.width
+
             //: Application title
             //% "Documents"
             title: qsTrId("sailfish-office-he-apptitle");
 
             // TODO: uncomment once there are more document sources
             // title: page.title;
+
+            Binding {
+                target: page
+                property: "searchText"
+                value: header.searchText
+            }
+
+            Connections {
+                target: menuItemSearch
+                onClicked: header.enableSearch()
+            }
+        }
+
+        PullDownMenu {
+            MenuItem {
+                id: menuItemSearch
+
+                //: Search menu entry
+                //% "Search"
+                text: qsTrId("sailfish-office-me-search")
+            }
         }
         
         ViewPlaceholder {
@@ -98,7 +123,7 @@ Page {
                         bottom: icon.verticalCenter;
                     }
                     color: (bg.highlighted || listItem.menuOpen) ? Theme.highlightColor : Theme.primaryColor
-                    text: model.fileName;
+                    text: searchText.length > 0 ? Theme.highlightText(model.fileName, searchText, Theme.highlightColor) : model.fileName
                     font.pixelSize: Theme.fontSizeMedium;
                     truncationMode: TruncationMode.Fade;
                 }

--- a/qml/SearchPageHeader.qml
+++ b/qml/SearchPageHeader.qml
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+FocusScope {
+    property alias title: pageHeader.title
+    property alias searchText: searchField.text
+
+    implicitHeight: col.height
+
+    function enableSearch() {
+        if (searchField.enabled) {
+            searchField.forceActiveFocus()
+        } else {
+            searchField.enabled = true
+        }
+    }
+
+    Column {
+        id: col
+        width: parent.width
+
+        PageHeader {
+            id: pageHeader
+            width: parent.width
+            visible: searchField.opacity === 0.
+        }
+
+        SearchField {
+            id: searchField
+            property bool open: opacity === 1.0
+
+            width: parent.width
+            enabled: false
+            opacity: enabled ? 1.0 : 0.0
+            visible: opacity > 0.
+
+            //: Document search field placeholder text
+            //% "Search documents"
+            placeholderText: qsTrId("sailfish-office-tf-search-documents")
+
+            // We prefer lowercase
+            inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase | Qt.ImhNoPredictiveText
+            EnterKey.iconSource: "image://theme/icon-m-enter-close"
+            EnterKey.onClicked: focus = false
+
+            onOpenChanged: if (open) forceActiveFocus()
+            onActiveFocusChanged: if (!activeFocus && text == "") enabled = false
+
+            Behavior on opacity { FadeAnimation { duration: 300 } }
+        }
+    }
+}

--- a/sailfishapplication.cpp
+++ b/sailfishapplication.cpp
@@ -33,6 +33,7 @@
 
 #include "sailfishapplication.h"
 #include "config.h"
+#include "models/filtermodel.h"
 #include "models/documentlistmodel.h"
 #include "models/trackerdocumentprovider.h"
 #include "models/documentproviderplugin.h"
@@ -65,6 +66,7 @@ QSharedPointer<QQuickView> Sailfish::createView(const QString &file)
     qmlRegisterType< DocumentListModel >( "Sailfish.Office.Files", 1, 0, "DocumentListModel" );
     qmlRegisterType< DocumentProviderListModel >( "Sailfish.Office.Files", 1, 0, "DocumentProviderListModel" );
     qmlRegisterType< TrackerDocumentProvider >( "Sailfish.Office.Files", 1, 0, "TrackerDocumentProvider" );
+    qmlRegisterType< FilterModel >( "Sailfish.Office.Files", 1, 0, "FilterModel" );
     qmlRegisterInterface< DocumentProviderPlugin >( "DocumentProviderPlugin" );
 
     QSharedPointer<QQuickView> view(MDeclarativeCache::qQuickView());


### PR DESCRIPTION
This pull request adds the capability to filter the document list to display a subpart of all documents on the phone. The filtering is done on file names only. The model is filtered when matching a subpart of the filename. This is convenient for instance to find a specific document, like when look for electricity bills or whatever.

I've added a QSortFilterProxyModel on the cpp side that works on DocumentListModel object. It is exported as a QML type "FilterModel".

I've added a SearchPageHeader QML component, inspired by the one of the media player (for UI consistency). This component displays a PageHeader or a SearchField. The SearchField is activated through a pulley menu.

What do you think ?