### PR TITLE
[office] correct an issue of content jumping when zooming near the end of long PDF files.

### DIFF
--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -49,22 +49,28 @@ SilicaFlickable {
 
     function zoom(amount, center) {
         var oldWidth = pdfCanvas.width;
+        var oldHeight = pdfCanvas.height
+        var oldContentX = contentX
+        var oldContentY = contentY
 
         pdfCanvas.width = clamp(pdfCanvas.width * amount);
 
-        var realZoom = pdfCanvas.width / oldWidth;
-        contentX += (center.x * realZoom) - center.x;
-        contentY += (center.y * realZoom) - center.y;
+        /* One cannot use += here because changing contentX will change contentY
+           to adjust to new height, so we use saved values. */
+        contentX = oldContentX + (center.x * pdfCanvas.width / oldWidth) - center.x
+        contentY = oldContentY + (center.y * pdfCanvas.height / oldHeight) - center.y
     }
 
     function adjust() {
         var oldWidth = pdfCanvas.width
         var oldHeight = pdfCanvas.height
+        var oldContentX = contentX
+        var oldContentY = contentY
 
         pdfCanvas.width = scaled ? clamp(pdfCanvas.width) : width
 
-        contentX *= pdfCanvas.width / oldWidth
-        contentY *= pdfCanvas.height / oldHeight
+        contentX = oldContentX * pdfCanvas.width / oldWidth
+        contentY = oldContentY * pdfCanvas.height / oldHeight
     }
 
     // Ensure proper zooming level when device is rotated.

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -57,17 +57,23 @@ SilicaFlickable {
         contentY += (center.y * realZoom) - center.y;
     }
 
+    function adjust() {
+        var oldWidth = pdfCanvas.width
+        var oldHeight = pdfCanvas.height
+
+        pdfCanvas.width = scaled ? clamp(pdfCanvas.width) : width
+
+        contentX *= pdfCanvas.width / oldWidth
+        contentY *= pdfCanvas.height / oldHeight
+    }
+
     // Ensure proper zooming level when device is rotated.
-    onWidthChanged: pdfCanvas.width = scaled ? clamp(pdfCanvas.width) : width
+    onWidthChanged: adjust()
 
     PDF.Canvas {
         id: pdfCanvas;
 
         width: base.width;
-        // When not zoomed, device rotation will change width and height,
-        // so, we shift content position with changing ratio.
-        onHeightChanged: if (!base.scaled) base.contentY *= height / base.contentHeight
-        onWidthChanged: if (!base.scaled) base.contentX *= width / base.contentWidth
 
         spacing: Theme.paddingLarge;
         flickable: base;


### PR DESCRIPTION
There is an issue with PDF files with many pages when zooming in or out near the end of the file. To reproduce :
* open a PDF file with many pages like http://www.free.fr/adsl/pdf/cgv-forfait-hors-opt-11072007.pdf ;
* jump to the last page and stay at the bottom;
* zoom in and out, from time to time, the view is jumping up and down.

This is due to two factors in the code :
* the zooming factor is not the same for the width and the height. Indeed, the height is cast to an int in pdfcanvas.cpp, so a rounding appears here ;
* the fact of affacting contentX to a new value in PDFView.qml zoom() function makes contentY changes also (I guess because height has changed and the view is adjusting its contentY accordingly to a value that makes the bottom part of the document stays at the bottom of the screen), one cannot use the += affectation that supposes that contentY contains the old value.

In the patch, I've addressed the first issue by using newWidth / oldWidth for width and newHeight / oldHeight for height instead of width factor for height also. The second issue is addressed by storing old values of contentX and contentY before affecting them.

