### PR TITLE
[office] Add a placeholder for the table of content of PDF documents.

### DIFF
--- a/pdf/pdftocmodel.cpp
+++ b/pdf/pdftocmodel.cpp
@@ -145,3 +145,8 @@ int PDFTocModel::rowCount(const QModelIndex& parent) const
         return 0;
     return d->entries.count();
 }
+
+int PDFTocModel::count() const
+{
+  return d->entries.count();
+}

--- a/pdf/pdftocmodel.h
+++ b/pdf/pdftocmodel.h
@@ -25,6 +25,7 @@ namespace Poppler { class Document; }
 class PDFTocModel : public QAbstractListModel
 {
     Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
     enum PDFTocModelRoles {
@@ -38,6 +39,11 @@ public:
     virtual QVariant data(const QModelIndex& index, int role) const;
     virtual int rowCount(const QModelIndex& parent) const;
     virtual QHash<int, QByteArray> roleNames() const;
+
+    int count() const;
+
+Q_SIGNALS:
+    void countChanged();
 
 private:
     class Private;

--- a/plugin/PDFDocumentToCPage.qml
+++ b/plugin/PDFDocumentToCPage.qml
@@ -35,6 +35,17 @@ Page {
         //% "Index"
         header: PageHeader { title: qsTrId( "sailfish-office-he-pdf_index" ); }
 
+        ViewPlaceholder {
+            id: placeholder
+            //% "Document has no table of content"
+            text: qsTrId("sailfish-office-me-no-toc")
+        }
+        // The enabled attribute of the placeholder is not set by binding since
+        // the model object comes from a different thread and QML cannot listen
+        // on signals from a different thread. Thus, the attribute is set by
+        // reading the count value instead of a binding.
+        onModelChanged: placeholder.enabled = !model || (model.count == 0)
+
         delegate: BackgroundItem {
             id: bg;
 


### PR DESCRIPTION
This adds a message for empty index page for PDF documents instead of showing an empty page.

The enabled attribute of the placeholder is not set by binding since the tocmodel object comes from a different thread and QML complains about signaling from a different thread. Thus, enabled attribute is set by javascript by reading the count value when model is set instead.