### PR TITLE
[office] fix issue #37, by hiding the pulldown menu when no documents.

### DIFF
--- a/qml/FileListPage.qml
+++ b/qml/FileListPage.qml
@@ -66,6 +66,7 @@ Page {
         }
 
         PullDownMenu {
+            visible: listView.count > 0
             MenuItem {
                 id: menuItemSearch
 


### PR DESCRIPTION
As explained in https://sailfishos.org/develop/docs/silica/sailfish-application-pitfalls.html/ I've added a visible attribute to the pull down menu.