### PR TITLE
[office] Correct zooming, increase the maximum zoom and disable the z…

### DIFF
--- a/plugin/SpreadsheetPage.qml
+++ b/plugin/SpreadsheetPage.qml
@@ -53,6 +53,8 @@ DocumentPage {
             id: controller;
             view: v;
             flickable: f;
+            useZoomProxy: false;
+            maximumZoom: 5.0;
         }
 
         children: [
@@ -65,7 +67,7 @@ DocumentPage {
 
             onPinchUpdated: {
                 var newCenter = mapToItem( f, pinch.center.x, pinch.center.y );
-                controller.zoomAroundPoint(pinch.scale - pinch.previousScale, newCenter.x, newCenter.y);
+                controller.zoomAroundPoint(controller.zoom * (pinch.scale - pinch.previousScale), newCenter.x, newCenter.y);
             }
             onPinchFinished: controller.zoomTimeout();
 

--- a/plugin/TextDocumentPage.qml
+++ b/plugin/TextDocumentPage.qml
@@ -48,6 +48,8 @@ DocumentPage {
             id: controller;
             view: v;
             flickable: f;
+            useZoomProxy: false;
+            maximumZoom: 5.0;
             minimumZoomFitsWidth: true;
         }
 
@@ -61,7 +63,7 @@ DocumentPage {
 
             onPinchUpdated: {
                 var newCenter = mapToItem( f, pinch.center.x, pinch.center.y );
-                controller.zoomAroundPoint(pinch.scale - pinch.previousScale, newCenter.x, newCenter.y);
+                controller.zoomAroundPoint(controller.zoom * (pinch.scale - pinch.previousScale), newCenter.x, newCenter.y);
             }
             onPinchFinished: controller.zoomTimeout();
 


### PR DESCRIPTION
…oom proxy. Fixes JB#30396

Increase the maximum zoom so that the document can be zoomed to a
greater amount on devices with larger screens.

Also, scaling wasn't working correctly (more noticeable when zooming
out than in); as zoomAroundPoint() applies the given scale amount by
adding it to the current zoom, the amount should be multiplied by the
scale difference rather than just passed directly.

This also disables the zoomProxy for these views, as the proxy display
is sometimes confused in the current version of Calligra -- sometimes
the proxy is displayed upside down when zooming out (presumably because
the scale applied to the proxy becomes negative).