### PR TITLE
[office] Add support for internal Goto link in PDF.

### DIFF
--- a/pdf/pdfcanvas.cpp
+++ b/pdf/pdfcanvas.cpp
@@ -164,12 +164,12 @@ void PDFCanvas::setDocument(PDFDocument* doc)
     }
 }
 
-qreal PDFCanvas::pagePosition(int index) const
+QRectF PDFCanvas::pageRectangle(int index) const
 {
     if( d->pages.count() == 0 )
-        return 0.f;
+        return QRectF();
 
-    return d->pages.value( index ).rect.y();
+    return d->pages.value( index ).rect;
 }
 
 int PDFCanvas::currentPage() const

--- a/pdf/pdfcanvas.h
+++ b/pdf/pdfcanvas.h
@@ -36,7 +36,7 @@ public:
     PDFCanvas(QQuickItem* parent = 0);
     ~PDFCanvas();
 
-    Q_INVOKABLE qreal pagePosition( int index ) const;
+    Q_INVOKABLE QRectF pageRectangle( int index ) const;
 
     QQuickItem *flickable() const;
     void setFlickable(QQuickItem *f);

--- a/pdf/pdflinkarea.cpp
+++ b/pdf/pdflinkarea.cpp
@@ -87,7 +87,12 @@ void PDFLinkArea::mouseReleaseEvent(QMouseEvent* event)
     } else if (url.isRelative() && url.hasQuery()) {
         QUrlQuery query = QUrlQuery(url);
         if (query.hasQueryItem("page")) {
-            emit gotoClicked(query.queryItemValue("page").toInt());
+            bool ok;
+            double top = query.queryItemValue("top").toFloat(&ok);
+            if (!ok) top = -1.;
+            double left = query.queryItemValue("left").toFloat(&ok);
+            if (!ok) left = -1.;
+            emit gotoClicked(query.queryItemValue("page").toInt(), top, left);
         } else {
             emit clicked();
         }

--- a/pdf/pdflinkarea.cpp
+++ b/pdf/pdflinkarea.cpp
@@ -18,6 +18,7 @@
 
 #include "pdflinkarea.h"
 #include "pdfcanvas.h"
+#include <QUrlQuery>
 
 class PDFLinkArea::Private
 {
@@ -81,10 +82,16 @@ void PDFLinkArea::mouseReleaseEvent(QMouseEvent* event)
     if( d->canvas )
         url = d->canvas->urlAtPoint( event->pos() );
 
-    if(url.isEmpty()) {
+    if (url.isEmpty()) {
         emit clicked();
-    }
-    else {
+    } else if (url.isRelative() && url.hasQuery()) {
+        QUrlQuery query = QUrlQuery(url);
+        if (query.hasQueryItem("page")) {
+            emit gotoClicked(query.queryItemValue("page").toInt());
+        } else {
+            emit clicked();
+        }
+    } else {
         emit linkClicked(url);
     }
     event->accept();

--- a/pdf/pdflinkarea.h
+++ b/pdf/pdflinkarea.h
@@ -38,6 +38,7 @@ Q_SIGNALS:
     void clicked();
     void doubleClicked();
     void linkClicked(QUrl linkTarget);
+    void gotoClicked(int page);
 
     void canvasChanged();
 

--- a/pdf/pdflinkarea.h
+++ b/pdf/pdflinkarea.h
@@ -38,7 +38,7 @@ Q_SIGNALS:
     void clicked();
     void doubleClicked();
     void linkClicked(QUrl linkTarget);
-    void gotoClicked(int page);
+    void gotoClicked(int page, qreal top, qreal left);
 
     void canvasChanged();
 

--- a/pdf/pdfrenderthread.cpp
+++ b/pdf/pdfrenderthread.cpp
@@ -92,12 +92,27 @@ public:
             Poppler::Page* page = document->page(i);
             for(Poppler::Link* link : page->links())
             {
-                if(link->linkType() == Poppler::Link::Browse)
-                {
+                switch (link->linkType()) {
+                case (Poppler::Link::Browse): {
                     Poppler::LinkBrowse* realLink = static_cast<Poppler::LinkBrowse*>(link);
                     QRectF linkArea = link->linkArea();
                     linkTargets.insert( i, QPair< QRectF, QUrl >{ linkArea, realLink->url() } );
+                    break;
                 }
+                case (Poppler::Link::Goto): {
+                    Poppler::LinkGoto* gotoLink = static_cast<Poppler::LinkGoto*>(link);
+                    // Not handling goto link to external file currently.
+                    if (gotoLink->isExternal())
+                        break;
+                    QRectF linkArea = link->linkArea();
+                    QString linkPage = QString("?page=%1").arg(gotoLink->destination().pageNumber());
+                    linkTargets.insert( i, QPair< QRectF, QUrl >{ linkArea, linkPage } );
+                    break;
+                }
+                default:
+                    break;
+                }
+
             }
         }
     }

--- a/pdf/pdfrenderthread.cpp
+++ b/pdf/pdfrenderthread.cpp
@@ -24,6 +24,7 @@
 #include <QMutex>
 #include <QDebug>
 #include <QCoreApplication>
+#include <QUrlQuery>
 
 #include <poppler-qt5.h>
 
@@ -105,8 +106,17 @@ public:
                     if (gotoLink->isExternal())
                         break;
                     QRectF linkArea = link->linkArea();
-                    QString linkPage = QString("?page=%1").arg(gotoLink->destination().pageNumber());
-                    linkTargets.insert( i, QPair< QRectF, QUrl >{ linkArea, linkPage } );
+                    QUrl linkURL = QUrl("");
+                    QUrlQuery query = QUrlQuery();
+                    query.addQueryItem("page", QString::number(gotoLink->destination().pageNumber()));
+                    if (gotoLink->destination().isChangeLeft()) {
+                        query.addQueryItem("left", QString::number(gotoLink->destination().left()));
+                    }
+                    if (gotoLink->destination().isChangeTop()) {
+                        query.addQueryItem("top", QString::number(gotoLink->destination().top()));
+                    }
+                    linkURL.setQuery(query);
+                    linkTargets.insert( i, QPair< QRectF, QUrl >{ linkArea, linkURL } );
                     break;
                 }
                 default:

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -144,6 +144,7 @@ SilicaFlickable {
 
                 canvas: pdfCanvas;
                 onLinkClicked: Qt.openUrlExternally(linkTarget);
+                onGotoClicked: base.goToPage(page - 1)
                 onClicked: base.clicked();
             }
         }

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -144,7 +144,8 @@ SilicaFlickable {
 
                 canvas: pdfCanvas;
                 onLinkClicked: Qt.openUrlExternally(linkTarget);
-                onGotoClicked: base.goToPage(page - 1)
+                onGotoClicked: base.goToPage(page - 1, top, left,
+                                             Theme.paddingLarge, Theme.paddingLarge)
                 onClicked: base.clicked();
             }
         }
@@ -179,7 +180,23 @@ SilicaFlickable {
         VerticalScrollDecorator { color: Theme.highlightDimmerColor; }
     ]
 
-    function goToPage(pageNumber) {
-        base.contentY = pdfCanvas.pagePosition( pageNumber );
+    function goToPage(pageNumber, top, left, topSpacing, leftSpacing) {
+        var rect = pdfCanvas.pageRectangle( pageNumber )
+        var scrollX, scrollY
+        // Adjust horizontal position if required.
+        scrollX = base.contentX
+        if (left !== undefined && left >= 0.) {
+            scrollX = rect.x + left * rect.width - ( leftSpacing !== undefined ? leftSpacing : 0.)
+        }
+        if (scrollX > contentWidth - width) {
+            scrollX = contentWidth - width
+        }
+        // Adjust vertical position.
+        scrollY = rect.y + (top === undefined ? 0. : top * rect.height) - ( topSpacing !== undefined ? topSpacing : 0.);
+        if (scrollY > contentHeight - height) {
+            scrollY = contentHeight - height
+        }
+        contentX = scrollX
+        contentY = scrollY
     }
 }


### PR DESCRIPTION
This adds partial support for internal links in PDF documents. It makes the view scrolls to the target page of the link. It should contribute to issue #42. Currently, the inside of the target page itself is not scrolled.