### PR TITLE
[office] Add a shape visual for each page that has not been yet rendered.

### DIFF
--- a/pdf/pdfcanvas.h
+++ b/pdf/pdfcanvas.h
@@ -30,6 +30,7 @@ class PDFCanvas : public QQuickItem
     Q_PROPERTY( QQuickItem* flickable READ flickable WRITE setFlickable NOTIFY flickableChanged )
     Q_PROPERTY( float spacing READ spacing WRITE setSpacing NOTIFY spacingChanged )
     Q_PROPERTY( QColor linkColor READ linkColor WRITE setLinkColor NOTIFY linkColorChanged )
+    Q_PROPERTY( QColor pagePlaceholderColor READ pagePlaceholderColor WRITE setPagePlaceholderColor NOTIFY pagePlaceholderColorChanged )
     Q_PROPERTY( int currentPage READ currentPage NOTIFY currentPageChanged )
 
 public:
@@ -61,6 +62,14 @@ public:
      * Setter for property #linkColor.
      */
     void setLinkColor( const QColor& color );
+    /**
+     * Getter for property #pagePlaceholderColor.
+     */
+    QColor pagePlaceholderColor() const;
+    /**
+     * Setter for property #pagePlaceholderColor.
+     */
+    void setPagePlaceholderColor( const QColor& color );
 
     /**
      * Getter for property #currentPage.
@@ -84,6 +93,7 @@ Q_SIGNALS:
     void flickableChanged();
     void spacingChanged();
     void linkColorChanged();
+    void pagePlaceholderColorChanged();
     void currentPageChanged();
     void pageLayoutChanged();
 

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -130,6 +130,7 @@ SilicaFlickable {
         spacing: Theme.paddingLarge;
         flickable: base;
         linkColor: Theme.highlightColor;
+        pagePlaceholderColor: Theme.highlightColor;
 
         PinchArea {
             anchors.fill: parent;


### PR DESCRIPTION
This is a small modification in the paint node method to display a diffused rectangle shape of a page when the page has not been rendered yet. This gives a minimal visual feedback of the position in the document for instance when scrolling fast, or when  going to the next search match several pages further.