### PR TITLE
Remember last page position for PDF documents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ configure_file(config.h.in config.h)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -fPIC -pie -rdynamic -Wall")
 
+add_subdirectory(settings)
 add_subdirectory(plugin)
 add_subdirectory(pdf)
 

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -16,6 +16,7 @@ install(FILES
     PDFDocumentPage.qml
     PDFDocumentToCPage.qml
     PDFView.qml
+    PDFStorage.js
     PresentationPage.qml
     PresentationThumbnailPage.qml
     SpreadsheetListPage.qml

--- a/plugin/PDFStorage.js
+++ b/plugin/PDFStorage.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+var Settings = function(file) {
+    this.db = LocalStorage.openDatabaseSync("sailfish-office", "1.0",
+                                            "Local storage for the document viewer.", 10000);
+    this.source = file
+}
+
+/* Different tables. */
+function createTableLastViewSettings(tx) {
+    /* Currently store the last page, may be altered later to store
+       zoom level or page position. */
+    tx.executeSql('CREATE TABLE IF NOT EXISTS LastViewSettings(
+                    file TEXT   NOT NULL,
+                    page INT    NOT NULL,
+                    top  REAL           ,
+                    left REAL           ,
+                    width INT CHECK(width > 0))');
+    tx.executeSql('CREATE UNIQUE INDEX IF NOT EXISTS idx_file ON LastViewSettings(file)');
+}
+
+/* Get and set operations. */
+Settings.prototype.getLastPage = function() {
+    var page = 0
+    var top = 0
+    var left = 0
+    var width = 0
+    var file = this.source
+    this.db.transaction(function(tx) {
+        createTableLastViewSettings(tx);
+        var rs = tx.executeSql('SELECT page, top, left, width FROM LastViewSettings WHERE file = ?', [file]);
+        if (rs.rows.length > 0) {
+            page = rs.rows.item(0).page;
+            top  = rs.rows.item(0).top;
+            left = rs.rows.item(0).left;
+            width = rs.rows.item(0).width;
+        }
+    });
+    // Return page is in [1:]
+    return [page, top, left, width];
+}
+Settings.prototype.setLastPage = function(page, top, left, width) {
+    // page is in [1:]
+    var file = this.source
+    this.db.transaction(function(tx) {
+        createTableLastViewSettings(tx);
+        var rs = tx.executeSql('INSERT OR REPLACE INTO LastViewSettings(file, page, top, left, width) VALUES (?,?,?,?,?)', [file, page, top, left, width]);
+    });
+}

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Office.PDF 1.0 as PDF
+import org.nemomobile.configuration 1.0
 import QtQuick.LocalStorage 2.0
 import "PDFStorage.js" as PDFStorage
 
@@ -124,7 +125,7 @@ SilicaFlickable {
     // Ensure proper zooming level when device is rotated.
     onWidthChanged: adjust()
 
-    Component.onDestruction: pdfCanvas.savePageSettings()
+    Component.onDestruction: if (rememberPositionConfig.value) pdfCanvas.savePageSettings()
     PDF.Canvas {
         id: pdfCanvas;
 
@@ -135,7 +136,7 @@ SilicaFlickable {
         linkColor: Theme.highlightColor;
         pagePlaceholderColor: Theme.highlightColor;
 
-        onPageLayoutChanged: restorePageSettings()
+        onPageLayoutChanged: if (rememberPositionConfig.value) restorePageSettings()
 
         // Handle save and restore the view settings.
         property var _settings
@@ -231,5 +232,12 @@ SilicaFlickable {
         }
         contentX = Math.max(0, scrollX)
         contentY = Math.max(0, scrollY)
+    }
+
+    ConfigurationValue {
+        id: rememberPositionConfig
+
+        key: "/apps/sailfish-office/settings/rememberPosition"
+        defaultValue: false
     }
 }

--- a/rpm/sailfish-office.spec
+++ b/rpm/sailfish-office.spec
@@ -45,6 +45,7 @@ Group: System/Base
 %{_datadir}/translations/*.qm
 %{_datadir}/dbus-1/interfaces/
 %{_datadir}/dbus-1/services/
+%{_datadir}/jolla-settings/
 
 %files ts-devel
 %{_datadir}/translations/source/*.ts

--- a/settings/CMakeLists.txt
+++ b/settings/CMakeLists.txt
@@ -1,0 +1,9 @@
+install(FILES
+    sailfish-office.json
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/jolla-settings/entries
+)
+
+install(FILES
+    office.qml
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/jolla-settings/pages/sailfish-office
+)

--- a/settings/office.qml
+++ b/settings/office.qml
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import org.nemomobile.configuration 1.0
+
+
+Page {
+    Column {
+        width: parent.width - 2 * Theme.horizontalPageMargin
+        anchors.horizontalCenter: parent.horizontalCenter
+        PageHeader {
+            //% "Documents"
+            title: qsTrId("settings_office-ph-documents")
+        }
+        TextSwitch {
+            //% "Remember page position"
+            text: qsTrId("settings_office-ts-remember")
+            checked: rememberPositionConfig.value
+            //% "Save page position and zoom level for a PDF document."
+            description: qsTrId("settings_office-ts-remember-desc")
+            onClicked: rememberPositionConfig.value = checked
+            width: parent.width
+        }
+
+    }
+    
+    ConfigurationValue {
+        id: rememberPositionConfig
+
+        key: "/apps/sailfish-office/settings/rememberPosition"
+        defaultValue: false
+    }
+}

--- a/settings/sailfish-office.json
+++ b/settings/sailfish-office.json
@@ -1,0 +1,15 @@
+{
+    "translation_catalog": "settings-sailfish-office",
+    "entries": [
+        {
+            "path": "applications/sailfish-office.desktop",
+            "title": "Documents",
+            "translation_id": "settings_applications-office",
+            "type": "page",
+            "icon": "image://theme/icon-m-documents",
+            "params": {
+                "source": "/usr/share/jolla-settings/pages/sailfish-office/office.qml"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
As described in the [TJC post](https://together.jolla.com/question/90317/help-improve-document-application/#lastpage), I propose here an implementation for the feature to remember last page position for PDF documents. It is based on :
* the use of a local SQlite database (see plugins/PDFStorage.js) with a table indexed by file path, containing the page index, the position in the page (in reduced coordinates) and the actual width of the page in pixel. I prefered to store these (more) abstract data, than the actual contentX, contentY and width, height of the PDFCanvas object, to be sure that the last position is properly reproduced when opening a file in landscape while position was stored in portrait (or vice-versa).
* I open a database connection every time a PDF file is taped and loaded to fetch for the possibly stored position data. I don't know if it's clever or not. I prefered this than a global variable owned by the document list and passed to the PDFView instance. Like that it is self contained in PDFView.
* the loading of the stored settings is done on the first emission of the pageLayoutChanged signal and not on Component.completed since, it's only after this signal that page geometries are known.
* the storing to the database is done on Component destruction. But there's a trick here I don't like. If I put the Component.onDestruction handler in the PDFCanvas instance, when triggered, the properties have been already destroyed (_settings attribute is null there). While putting the signal handler in the parent (the PDFView instance), the child is not destroyed yet, and I can do things with _settings. It's fragile IMHO since the Qt documentation explicitly says that the order of destroying is not guaranteed. But I have no other idea. I've tried in fact to react on the page transition, which works fine, but saving is not done when we quit the application directly, which is a no go of course.
* Finally the PR is divided into two commits, one to bring all the machinery for storing the page data, the other one to add a setting for the document application to enable or not this feature (that may be disturbing first to go back on a big zoom level in a middle page while not knowing about this, so it's an opt-in feature).

Sorry, long text, but for this feature that seems so simple (even to implement), it finally requires many explanations since many choices were done.