### PR TITLE
[office] Implement persitent storage of page location for PDF documents (QML + JS).

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -16,6 +16,7 @@ install(FILES
     PDFDocumentPage.qml
     PDFDocumentToCPage.qml
     PDFView.qml
+    PDFStorage.js
     PresentationPage.qml
     PresentationThumbnailPage.qml
     SpreadsheetListPage.qml

--- a/plugin/PDFStorage.js
+++ b/plugin/PDFStorage.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+var Settings = function(file) {
+    this.db = LocalStorage.openDatabaseSync("sailfish-office", "1.0",
+                                            "Local storage for the document viewer.", 10000);
+    this.source = file
+}
+
+/* Different tables. */
+function createTableLastViewSettings(tx) {
+    /* Currently store the last page, may be altered later to store
+       zoom level or page position. */
+    tx.executeSql('CREATE TABLE IF NOT EXISTS LastViewSettings(
+                    file TEXT   NOT NULL,
+                    page INT    NOT NULL,
+                    top  REAL           ,
+                    left REAL           ,
+                    width INT CHECK(width > 0))');
+    tx.executeSql('CREATE UNIQUE INDEX IF NOT EXISTS idx_file ON LastViewSettings(file)');
+}
+
+/* Get and set operations. */
+Settings.prototype.getLastPage = function() {
+    var page = 0
+    var top = 0
+    var left = 0
+    var width = 0
+    var file = this.source
+    this.db.transaction(function(tx) {
+        createTableLastViewSettings(tx);
+        var rs = tx.executeSql('SELECT page, top, left, width FROM LastViewSettings WHERE file = ?', [file]);
+        if (rs.rows.length > 0) {
+            page = rs.rows.item(0).page;
+            top  = rs.rows.item(0).top;
+            left = rs.rows.item(0).left;
+            width = rs.rows.item(0).width;
+        }
+    });
+    // Return page is in [1:]
+    return [page, top, left, width];
+}
+Settings.prototype.setLastPage = function(page, top, left, width) {
+    // page is in [1:]
+    var file = this.source
+    this.db.transaction(function(tx) {
+        createTableLastViewSettings(tx);
+        var rs = tx.executeSql('INSERT OR REPLACE INTO LastViewSettings(file, page, top, left, width) VALUES (?,?,?,?,?)', [file, page, top, left, width]);
+    });
+}


### PR DESCRIPTION
I've taken back the QML + JS implementation of the remember page position PR. I've corrected what has been discussed in #47:
* I've not included the setting page to turn this on and off. It's still dependent on a dconf key, but it's true by default.
* I've moved the handling of SQL storing / restoring from PDFView to the main PDFDocumentPage object. Like that, the PDFView is kept simple stupid (and possibly reusable for simple PDF display).
* The storing is done on page status becoming inactive and on Qt.application sending aboutToQuit. It seems to work like that.
* The restoring is done on a new signal from PDFView that is emitted once when the page sizes of the PDF document have been computed.

Sorry for this feature implementation taking so much review time from you. I appreciate your remarks and I think that the result looks better. What do you think ?