### PR TITLE
[office] Implement partial page rendering to allow unlimited zoom.

### DIFF
--- a/pdf/pdfcanvas.cpp
+++ b/pdf/pdfcanvas.cpp
@@ -56,6 +56,7 @@ class PDFCanvas::Private
 public:
     Private(PDFCanvas *qq)
         : q(qq)
+        , pageSizeRequested(false)
         , pageCount(0)
         , currentPage(1)
         , renderWidth(0)
@@ -69,6 +70,7 @@ public:
     PDFCanvas *q;
 
     QHash<int, PDFPage> pages;
+    bool pageSizeRequested;
 
     int pageCount;
     int currentPage;
@@ -252,7 +254,10 @@ void PDFCanvas::setPagePlaceholderColor(const QColor &color)
 void PDFCanvas::layout()
 {
     if (d->pageSizes.count() == 0) {
-        d->document->requestPageSizes();
+        if (d->document->isLoaded() && !d->pageSizeRequested) {
+            d->document->requestPageSizes();
+            d->pageSizeRequested = true;
+        }
         return;
     }
 
@@ -425,8 +430,8 @@ QSGNode* PDFCanvas::updatePaintNode(QSGNode *node, QQuickItem::UpdatePaintNodeDa
     };
     QRect textureLimit = {
         0, 0,
-        2.5 * qMin(window()->width(), window()->height()),
-        2.5 * qMin(window()->width(), window()->height())
+        int(2.5 * qMin(window()->width(), window()->height())),
+        int(2.5 * qMin(window()->width(), window()->height()))
     };
     float renderingRatio = float(d->renderWidth) / width();
 
@@ -608,6 +613,7 @@ void PDFCanvas::resizeTimeout()
 void PDFCanvas::pageSizesFinished(const QList<QSizeF> &sizes)
 {
     d->pageSizes = sizes;
+    d->pageSizeRequested = false;
     layout();
 }
 

--- a/pdf/pdfcanvas.h
+++ b/pdf/pdfcanvas.h
@@ -119,7 +119,8 @@ protected:
     virtual QSGNode* updatePaintNode(QSGNode *node, UpdatePaintNodeData*);
 
 private Q_SLOTS:
-    void pageFinished(int id, QSGTexture *texture);
+    void pageFinished(int id, int pageRenderWidth,
+                      QRect subpart, QSGTexture *texture);
     void documentLoaded();
     void resizeTimeout();
     void pageSizesFinished(const QList<QSizeF> &sizes);

--- a/pdf/pdfdocument.cpp
+++ b/pdf/pdfdocument.cpp
@@ -152,20 +152,20 @@ void PDFDocument::requestUnLock(const QString &password)
     d->thread->queueJob(job);
 }
 
-void PDFDocument::requestPage(int index, int size, QQuickWindow *window )
+void PDFDocument::requestPage(int index, int size, QQuickWindow *window, QRect subpart)
 {
     if (!isLoaded() || isLocked())
         return;
 
-    RenderPageJob* job = new RenderPageJob(index, size, window);
+    RenderPageJob* job = new RenderPageJob(index, size, window, subpart);
     d->thread->queueJob(job);
 }
 
-void PDFDocument::prioritizeRequest(int index, int size)
+void PDFDocument::prioritizeRequest(int index, int size, QRect subpart)
 {
     if (!isLoaded() || isLocked())
         return;
-    d->thread->prioritizeJob(index, size);
+    d->thread->prioritizeRenderJob(index, size, subpart);
 }
 
 void PDFDocument::cancelPageRequest(int index)
@@ -221,7 +221,7 @@ void PDFDocument::jobFinished(PDFJob *job)
     }
     case PDFJob::RenderPageJob: {
         RenderPageJob* j = static_cast<RenderPageJob*>(job);
-        emit pageFinished(j->m_index, j->m_page);
+        emit pageFinished(j->m_index, j->renderWidth(), j->m_subpart, j->m_page);
         break;
     }
     case PDFJob::PageSizesJob: {

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -71,8 +71,8 @@ public:
 public Q_SLOTS:
     void setSource(const QString &source);
     void requestUnLock(const QString &password);
-    void requestPage(int index, int size, QQuickWindow *window);
-    void prioritizeRequest(int index, int size);
+    void requestPage(int index, int size, QQuickWindow *window, QRect subpart = QRect());
+    void prioritizeRequest(int index, int size, QRect subpart = QRect());
     void cancelPageRequest(int index);
     void requestPageSizes();
     void search(const QString &search, uint startPage = 0);
@@ -89,7 +89,7 @@ Q_SIGNALS:
     void documentLoadedChanged();
     void documentFailedChanged();
     void documentLockedChanged();
-    void pageFinished(int index, QSGTexture *page);
+    void pageFinished(int index, int resolution, QRect subpart, QSGTexture *page);
     void pageSizesFinished(const QList<QSizeF> &heights);
 
 private:

--- a/pdf/pdfjob.h
+++ b/pdf/pdfjob.h
@@ -84,14 +84,16 @@ class RenderPageJob : public PDFJob
 {
     Q_OBJECT
 public:
-    RenderPageJob(int index, uint width, QQuickWindow *window);
+    RenderPageJob(int index, uint width, QQuickWindow *window, QRect  subpart = QRect());
 
     virtual void run();
 
     int m_index;
+    QRect m_subpart;
     QSGTexture *m_page;
 
     int renderWidth() const { return m_width; }
+    void changeRenderWidth(int width) { m_width = width; }
 
 private:
     QQuickWindow *m_window;

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -47,7 +47,7 @@ public:
 
     void queueJob(PDFJob *job);
     void cancelRenderJob(int index);
-    void prioritizeJob(int index, int size);
+    void prioritizeRenderJob(int index, int size, QRect subpart);
 
 Q_SIGNALS:
     void loadFinished();

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -40,7 +40,7 @@ SilicaFlickable {
     signal updateSize(real newWidth, real newHeight)
 
     function clamp(value) {
-        var maximumZoom = Math.min(Screen.height, Screen.width) * 2.5
+        var maximumZoom = Math.min(Screen.height, Screen.width) * 10
         return Math.max(width, Math.min(value, maximumZoom))
     }
 

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Office.PDF 1.0 as PDF
+import org.nemomobile.configuration 1.0
 
 SilicaFlickable {
     id: base
@@ -40,7 +41,7 @@ SilicaFlickable {
     signal updateSize(real newWidth, real newHeight)
 
     function clamp(value) {
-        var maximumZoom = Math.min(Screen.height, Screen.width) * 10
+        var maximumZoom = Math.min(Screen.height, Screen.width) * maxZoomLevelConfig.value
         return Math.max(width, Math.min(value, maximumZoom))
     }
 
@@ -270,6 +271,13 @@ SilicaFlickable {
         HorizontalScrollDecorator { color: Theme.highlightDimmerColor },
         VerticalScrollDecorator { color: Theme.highlightDimmerColor }
     ]
+
+    ConfigurationValue {
+        id: maxZoomLevelConfig
+
+        key: "/apps/sailfish-office/settings/maxZoomLevel"
+        defaultValue: 10.
+    }
 
     function goToPage(pageNumber, top, left, topSpacing, leftSpacing) {
         var rect = pdfCanvas.pageRectangle( pageNumber )


### PR DESCRIPTION
There is a TJC question about being able to increase the zoom level for PDFs : https://together.jolla.com/question/1763/unlimited-zoom-needed-in-document-viewer/

The limit is currently hardcoded in PDFView.qml, and set to 2.5. I understand that this limit is used to avoid having too big textures and limit memory consumption. But that would be convenient to be able to change this value anyway, knowing what we're doing. There is even a patch for patch manager to do this : https://openrepos.net/content/ancelad/patch-gallery-image-zoom . The patch, actually, uses a dconf key value instead of the hardcoded 2.5. So like that, one can create a GUI or even change via command line the setting.

The PR, I propose, just changes the hardcoded value for a dconf key (like the idea in the patch). The dconf key is loaded in PDFDocumentPage.qml (like the dconf key for the remember page position) so PDFView.qml is kept simple.

What do you think, this PR may conciliate the memory consumption limit for everyone and the need of some to easily raises the limit in some cases (in a more robust way than a patch) ?