### PR TITLE
[sailfish-office] Fix pdf document image grabbing. Contributes to JB#31599

### DIFF
--- a/qml/CoverPage.qml
+++ b/qml/CoverPage.qml
@@ -22,9 +22,17 @@ import Sailfish.Silica 1.0
 CoverBackground {
     id: root
 
-    property bool update: status === Cover.Active || Qt.application.active
-
-    onUpdateChanged: previewImage.updatePreview()
+    // While peeking both main window and cover window are visible at the
+    // same time. Thus, we can capture from main window when cover
+    // becomes visible.
+    // Note: this may change in future.
+    onVisibleChanged: {
+        if (visible) {
+            previewImage.updatePreview()
+        } else if (window.visible) {
+            previewImage.source = ""
+        }
+    }
 
     CoverPlaceholder {
         //: Cover placeholder shown when there are no documents
@@ -72,9 +80,10 @@ CoverBackground {
                                              window.documentItem.contentAvailable)
 
             function updatePreview() {
-                if (window.documentItem && root.update) {
-                    window.documentItem.grabToImage(function(result) { previewImage.source = result.url },
-                                                             Qt.size(width, height))
+                if (window.visible && window.documentItem) {
+                    window.documentItem.grabToImage(function(result) {
+                        previewImage.source = result.url
+                    }, Qt.size(width, height))
                 }
             }
             Connections {


### PR DESCRIPTION
This requires a small change on Sailfish Silica. Thus, left the ```updateCover``` but in practice that could be removed. If everybody agrees, I'd like to drop it already now.

Idea here is that content is grab when peeking starts (cover becomes visible) and released when cover is invisible and application window is visible (in practice at foreground). The releasing part guarantees that the old captured document doesn't flicker on the cover.

In addition, grabbing is done only if application window is visible (main window). Currently you can see errors printed from QQuickItemGrabResultPrivate::create we're trying to grab when main window is already hidden.