### PR TITLE
[office] modify link selection on tap for a better sensivity.

### DIFF
--- a/pdf/pdfcanvas.h
+++ b/pdf/pdfcanvas.h
@@ -33,6 +33,7 @@ class PDFCanvas : public QQuickItem
     Q_PROPERTY(QColor linkColor READ linkColor WRITE setLinkColor NOTIFY linkColorChanged)
     Q_PROPERTY(QColor pagePlaceholderColor READ pagePlaceholderColor WRITE setPagePlaceholderColor NOTIFY pagePlaceholderColorChanged)
     Q_PROPERTY(int currentPage READ currentPage NOTIFY currentPageChanged)
+    Q_PROPERTY(float linkWiggle READ linkWiggle WRITE setLinkWiggle NOTIFY linkWiggleChanged)
 
 public:
     PDFCanvas(QQuickItem *parent = 0);
@@ -54,6 +55,9 @@ public:
      * Setter for property #spacing.
      */
     void setSpacing(float newValue);
+
+    float linkWiggle() const;
+    void setLinkWiggle(float newValue);
 
     /**
      * Getter for property #linkColor.
@@ -97,6 +101,7 @@ Q_SIGNALS:
     void pagePlaceholderColorChanged();
     void currentPageChanged();
     void pageLayoutChanged();
+    void linkWiggleChanged();
 
 protected:
     virtual void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry);

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -133,6 +133,7 @@ SilicaFlickable {
 
         spacing: Theme.paddingLarge
         flickable: base
+        linkWiggle: Theme.itemSizeMedium / 2
         linkColor: Theme.highlightColor
         pagePlaceholderColor: Theme.highlightColor
 


### PR DESCRIPTION
As discussed when dealing with PR #43, link can be quite difficult to tap on, especially for internal goto links that can be used for references with very tiny link box… We agreed then that it could be a good idea to try to find links on closest distance instead of the current implementation of augmented link boxes.

This PR introduces a square distance calculation that equals to zero inside a link box, and equals to the distance to the closest point on the link box border when outside. Then the link is chosen as the one with the closest value on all links within a wiggle room.

To be dpi independant, the wiggle room (which is in pixel in C++) is chosen in QML as the size of an itemSizeMedium / 2, making links easily reachable (they are more or less the size of a thumb with this choice).