### PR TITLE
[office] Use new PasswordField item to unlock PDFs.

### DIFF
--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -264,17 +264,12 @@ DocumentPage {
                 height: Theme.paddingLarge
             }
 
-            TextField {
+            PasswordField {
                 id: password
 
                 visible: pdfDocument.locked
                 x: Theme.horizontalPageMargin
                 width: parent.width - 2*x
-                //% "password"
-                label: qsTrId("sailfish-office-la-password")
-                placeholderText: label
-                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
-                echoMode: TextInput.Password
                 EnterKey.enabled: text
                 EnterKey.iconSource: "image://theme/icon-m-enter-accept"
                 EnterKey.onClicked: {

--- a/rpm/sailfish-office.spec
+++ b/rpm/sailfish-office.spec
@@ -16,7 +16,7 @@ BuildRequires: cmake
 BuildRequires: qt5-qttools-linguist
 Requires: calligra-components >= 2.7.9+git4
 Requires: calligra-filters >= 2.7.9+git4
-Requires: sailfishsilica-qt5 >= 0.13.44
+Requires: sailfishsilica-qt5 >= 0.21.63
 Requires: sailfish-components-accounts-qt5
 Requires: libqt5sparql-tracker
 Requires: mapplauncherd >= 4.1.17


### PR DESCRIPTION
Minor changes to be in coherence with the rest of password entries in Sailfish.

I've raised the silica version requirement, but without knowing when PasswordField was exactly introduced, I put it to the version currently in SF2.0.1.

I'm wondering if these kinds of minor PR can save your time by just looking at it and accepting (if allright of course), or if you prefer to track these small changes internally ?