### PR TITLE
[office] Correct an issue with large links not working.

### DIFF
--- a/pdf/pdfrenderthread.cpp
+++ b/pdf/pdfrenderthread.cpp
@@ -90,10 +90,15 @@ public:
             Poppler::Page *page = document->page(i);
             QList<Poppler::Link*> links = page->links();
             for (Poppler::Link* link : links) {
+                // link->linkArea() may return negative heights,
+                // as mentioned in Freedesktop bug:
+                // https://bugs.freedesktop.org/show_bug.cgi?id=93900
+                // To avoid later unexpected asumption on height,
+                // link->linkArea() is normalized.
                 switch (link->linkType()) {
                 case (Poppler::Link::Browse): {
                     Poppler::LinkBrowse *realLink = static_cast<Poppler::LinkBrowse*>(link);
-                    QRectF linkArea = link->linkArea();
+                    QRectF linkArea = link->linkArea().normalized();
                     linkTargets.insert(i, QPair<QRectF, QUrl>(linkArea, realLink->url()));
                     break;
                 }
@@ -102,7 +107,7 @@ public:
                     // Not handling goto link to external file currently.
                     if (gotoLink->isExternal())
                         break;
-                    QRectF linkArea = link->linkArea();
+                    QRectF linkArea = link->linkArea().normalized();
                     QUrl linkURL = QUrl("");
                     QUrlQuery query = QUrlQuery();
                     query.addQueryItem("page", QString::number(gotoLink->destination().pageNumber()));


### PR DESCRIPTION
Quite embarassing, I've mixed bottom() and top() for QRectF in last commit for links.

In fact, I've looked at the Qt documentation (5.5 version on the web) and it mentions that top() is equivalent to y(), thus I wrote the previous commit according to this. But I notice an issue (links not working) when the link height is bigger than the wiggle. Debugging on the phone, I noticed that top() is in fact y() + height(). So I don't know if it's a documentation issue on the web or if top() and bottom() were exchanged between Qt5.2 and Qt5.5.

What your opinion ?

[Example of PDF with large links not working currently](https://github.com/sailfishos/sailfish-office/files/106478/CALISTE_DAMIEN-YA6FPQ.pdf)