### PR TITLE
Implement text selection in PDF documents

### DIFF
--- a/pdf/CMakeLists.txt
+++ b/pdf/CMakeLists.txt
@@ -11,6 +11,7 @@ set(pdfplugin_SRCS
     pdfcanvas.cpp
     pdflinkarea.cpp
     pdfsearchmodel.cpp
+    pdfselection.cpp
 )
 
 add_library(sailfishofficepdfplugin MODULE ${pdfplugin_SRCS})

--- a/pdf/pdfcanvas.h
+++ b/pdf/pdfcanvas.h
@@ -86,12 +86,23 @@ public:
     /**
      * \return The url of the link at point or an empty url if there is no link at point.
      */
-    QUrl urlAtPoint(const QPoint &point);
+    QUrl urlAtPoint(const QPointF &point);
+    QPair<int, QRectF> pageAtPoint(const QPointF &point) const;
     /**
      * \return A rectangle in the canvas coordinates from a rectangle
      * in page coordinates. Index is the index of the page.
      */
-    Q_INVOKABLE QRectF fromPageToItem(int index, const QRectF &rect);
+    Q_INVOKABLE QRectF fromPageToItem(int index, const QRectF &rect) const;
+    Q_INVOKABLE QPointF fromPageToItem(int index, const QPointF &point) const;
+    /**
+     * Provide a distance measure from @point to a rectangle given by @reducedCoordRect.
+     * @point is given in PDFCanvas coordinates, while @reducedCoordRect is in
+     * reduced coordinates and will be converted to PDFCanvas coordinates thanks
+     * to @pageRect. @pageRect can be obtained by calling pageAtPoint().
+     */
+    qreal squaredDistanceFromRect(const QRectF &pageRect,
+                                  const QRectF &reducedCoordRect,
+                                  const QPointF &point);
 
 Q_SIGNALS:
     void documentChanged();

--- a/pdf/pdfdocument.cpp
+++ b/pdf/pdfdocument.cpp
@@ -108,6 +108,11 @@ PDFDocument::LinkMap PDFDocument::linkTargets() const
     return d->thread->linkTargets();
 }
 
+PDFDocument::TextList PDFDocument::textBoxesAtPage(int page)
+{
+    return d->thread->textBoxesAtPage(page);
+}
+
 void PDFDocument::classBegin()
 {
 }

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -26,10 +26,7 @@
 #include <QtQuick/QSGTexture>
 #include <QtQuick/QQuickWindow>
 
-namespace Poppler {
-    class Document;
-    class Page;
-}
+#include <poppler-qt5.h>
 
 class PDFJob;
 
@@ -53,6 +50,7 @@ public:
 
 public:
     typedef QMultiMap<int, QPair<QRectF, QUrl> > LinkMap;
+    typedef QList<QPair<QRectF, Poppler::TextBox*> > TextList;
 
     QString source() const;
     int pageCount() const;
@@ -61,6 +59,7 @@ public:
     QObject* searchModel() const;
     
     LinkMap linkTargets() const;
+    TextList textBoxesAtPage(int page);
 
     bool isLoaded() const;
     bool isFailed() const;

--- a/pdf/pdflinkarea.h
+++ b/pdf/pdflinkarea.h
@@ -40,13 +40,19 @@ Q_SIGNALS:
     void doubleClicked();
     void linkClicked(QUrl linkTarget);
     void gotoClicked(int page, qreal top, qreal left);
+    void longPress(QPointF pressAt);
 
     void canvasChanged();
 
 protected:
     virtual void mousePressEvent(QMouseEvent *event);
+    virtual void mouseMoveEvent(QMouseEvent *event);
     virtual void mouseReleaseEvent(QMouseEvent *event);
     virtual void mouseDoubleClickEvent(QMouseEvent *event);
+    virtual void mouseUngrabEvent();
+
+private Q_SLOTS:
+    void pressTimeout();
 
 private:
     class Private;

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -24,6 +24,8 @@
 #include <QtCore/QMultiMap>
 #include <QtGui/QImage>
 
+#include <poppler-qt5.h>
+
 class QSize;
 class PDFJob;
 class PDFRenderThreadPrivate;
@@ -41,6 +43,7 @@ public:
     bool isFailed() const;
     bool isLocked() const;
     QMultiMap<int, QPair<QRectF, QUrl> > linkTargets() const;
+    QList<QPair<QRectF, Poppler::TextBox*> > textBoxesAtPage(int page);
 
     void queueJob(PDFJob *job);
     void cancelRenderJob(int index);

--- a/pdf/pdfselection.cpp
+++ b/pdf/pdfselection.cpp
@@ -1,0 +1,566 @@
+/*
+ * Copyright (C) 2015-2016 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "pdfselection.h"
+#include "pdfdocument.h"
+
+class PDFSelection::Private
+{
+public:
+    Private()
+        : canvas(nullptr)
+        , pageIndexStart(-1)
+        , boxIndexStart(-1)
+        , pageIndexStop(-1)
+        , boxIndexStop(-1)
+        , wiggle(4.)
+    {
+    }
+
+    PDFCanvas *canvas;
+
+    QPointF start;
+    QPointF stop;
+
+    int pageIndexStart;
+    int boxIndexStart;
+
+    int pageIndexStop;
+    int boxIndexStop;
+
+    bool handleReversed;
+
+    qreal wiggle;
+
+    enum Position {
+        At,
+        Before,
+        After
+    };
+    void textBoxAtIndex(int index, int *pageIndex, int *boxIndex);
+    void textBoxAtPoint(const QPointF &point, Position position, int *pageIndex, int *boxIndex);
+    int sliceCount(int pageIndex1, int boxIndex1, int pageIndex2, int boxIndex2) const;
+    int count() const;
+};
+
+PDFSelection::PDFSelection(QObject *parent)
+  : QAbstractListModel(parent), d(new Private)
+{
+}
+
+PDFSelection::~PDFSelection()
+{
+    delete d;
+}
+
+QHash<int, QByteArray> PDFSelection::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+
+    roles.insert(Rect, "rect");
+    roles.insert(Text, "text");
+
+    return roles;
+}
+
+void PDFSelection::Private::textBoxAtIndex(int index, int *pageIndex, int *boxIndex)
+{
+    *pageIndex = -1;
+    *boxIndex = -1;
+    PDFDocument *doc = canvas->document();
+    if (doc != nullptr) {
+        int count_ = count();
+        while (index < 0)
+            index += count_;
+        while (index >= count_)
+            index -= count_;
+        *boxIndex = index + boxIndexStart;
+        for (*pageIndex = pageIndexStart;
+             *pageIndex <= pageIndexStop; *pageIndex += 1) {
+            int nBoxes = doc->textBoxesAtPage(*pageIndex).count();
+            if (*boxIndex < nBoxes)
+                return;
+            else
+              *boxIndex -= nBoxes;
+        }
+    }
+}
+
+QVariant PDFSelection::data(const QModelIndex& index, int role) const
+{
+    if (!d->canvas)
+        return QVariant();
+    PDFDocument *doc = d->canvas->document();
+    if (!doc)
+        return QVariant();
+
+    int pageIndex = -1;
+    int boxIndex;
+    QVariant result;
+
+    if (index.isValid())
+        d->textBoxAtIndex(index.row(), &pageIndex, &boxIndex);
+    if (pageIndex >= 0) {
+        const PDFDocument::TextList &boxes = doc->textBoxesAtPage(pageIndex);
+        const QPair<QRectF, Poppler::TextBox*> &box = boxes.at(boxIndex);
+        switch(role) {
+        case Rect:
+            result.setValue<QRectF>(d->canvas->fromPageToItem(pageIndex, box.first));
+            break;
+        case Text:
+            result.setValue<QString>(box.second->text());
+            break;
+        default:
+            result.setValue<QString>(QString("Unknown role: %1").arg(role));
+            break;
+        }
+    }
+    return result;
+}
+
+QPair<int, QRectF> PDFSelection::rectAt(int index) const
+{
+    if (!d->canvas)
+        return QPair<int, QRectF>();
+    PDFDocument *doc = d->canvas->document();
+    if (!doc)
+        return QPair<int, QRectF>();
+
+    int pageIndex, boxIndex;
+    d->textBoxAtIndex(index, &pageIndex, &boxIndex);
+    if (pageIndex < 0)
+        return QPair<int, QRectF>();
+
+    const PDFDocument::TextList &boxes = doc->textBoxesAtPage(pageIndex);
+    const QPair<QRectF, Poppler::TextBox*> &box = boxes.at(boxIndex);
+    return QPair<int, QRectF> {pageIndex, box.first};
+}
+
+int PDFSelection::rowCount(const QModelIndex& parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return count();
+}
+
+int PDFSelection::Private::sliceCount(int pageIndex1, int boxIndex1,
+                                      int pageIndex2, int boxIndex2) const
+{
+    if (!canvas)
+        return 0;
+    PDFDocument *doc = canvas->document();
+    if (!doc)
+        return 0;
+
+    if (pageIndex1 < pageIndex2 ||
+        (pageIndex1 == pageIndex2 && boxIndex1 < boxIndex2)) {
+        int n = -boxIndex1;
+        for (int i = pageIndex1; i < pageIndex2; i++)
+            n += doc->textBoxesAtPage(i).count();
+        return n + boxIndex2;
+    } else {
+        int n = -boxIndex2;
+        for (int i = pageIndex2; i < pageIndex1; i++)
+            n += doc->textBoxesAtPage(i).count();
+        return -n - boxIndex1;
+    }
+}
+
+int PDFSelection::Private::count() const
+{
+    if (pageIndexStart < 0 || pageIndexStop < 0 ||
+        boxIndexStart < 0 || boxIndexStop < 0) {
+        return 0;
+    }
+
+    if (!canvas || !canvas->document())
+        return 0;
+
+    return sliceCount(pageIndexStart, boxIndexStart,
+                      pageIndexStop, boxIndexStop) + 1;
+}
+
+int PDFSelection::count() const
+{
+    return d->count();
+}
+
+PDFCanvas* PDFSelection::canvas() const
+{
+    return d->canvas;
+}
+
+void PDFSelection::setCanvas(PDFCanvas *newCanvas)
+{
+    if (newCanvas != d->canvas) {
+        if (d->canvas)
+            d->canvas->disconnect(this);
+        d->canvas = newCanvas;
+
+        connect(d->canvas, &PDFCanvas::pageLayoutChanged,
+                this, &PDFSelection::onLayoutChanged);
+
+        emit canvasChanged();
+
+        onLayoutChanged();
+    }
+}
+
+float PDFSelection::wiggle() const
+{
+    return d->wiggle;
+}
+
+void PDFSelection::setWiggle(float newValue)
+{
+    if (newValue != d->wiggle) {
+        d->wiggle = newValue;
+        emit wiggleChanged();
+    }
+}
+
+// TODO: update the Before and After cases to handle RTL languages.
+void PDFSelection::Private::textBoxAtPoint(const QPointF &point, Position position,
+                                           int *pageIndex, int *boxIndex)
+{
+    *pageIndex = -1;
+    *boxIndex  = -1;
+    if (!canvas || !canvas->document())
+        return;
+    
+    // point is given in canvas coordinates.
+    QPair<int, QRectF> at = canvas->pageAtPoint(point);
+    if (at.first < 0)
+        return;
+    *pageIndex = at.first;
+
+    const PDFDocument::TextList &boxes = canvas->document()->textBoxesAtPage(*pageIndex);
+    switch (position) {
+    case PDFSelection::Private::At: {
+        qreal squaredDistanceMin = wiggle * wiggle;
+        int i = 0;
+        for (PDFDocument::TextList::const_iterator box = boxes.begin();
+             box != boxes.end(); box++) {
+            qreal squaredDistance =
+                canvas->squaredDistanceFromRect(at.second, box->first, point);
+                
+            if (squaredDistance < squaredDistanceMin) {
+                *boxIndex = i;
+                squaredDistanceMin = squaredDistance;
+            }
+            i += 1;
+        }
+        break;
+    }
+    case PDFSelection::Private::Before: {
+        // Find the last box index in pageIndex that is before @point,
+        // including at @point. If none is found in this page, returns
+        // the last box of the previous page.
+        QPointF reducedCoordPoint {point.x() / at.second.width(),
+                (point.y() - at.second.y()) / at.second.height()};
+        for (PDFDocument::TextList::const_iterator box = boxes.begin();
+             box != boxes.end(); box++) {
+            /* Stop counting boxes up as soon as a box after reducedCoordPoint is found. */
+            if (box->first.y() > reducedCoordPoint.y() ||
+                (box->first.y() + box->first.height() > reducedCoordPoint.y() &&
+                 box->first.x() > reducedCoordPoint.x())) {
+                if (*boxIndex == -1) {
+                    *pageIndex -= 1;
+                    if (*pageIndex >= 0)
+                        *boxIndex = canvas->document()->textBoxesAtPage(*pageIndex).length() - 1;
+                }
+                return;
+            }
+            *boxIndex += 1;
+        }
+        *boxIndex = boxes.length() - 1;
+        break;
+    }
+    case PDFSelection::Private::After: {
+        // Find the first box index in pageIndex that is after @point,
+        // including at @point. If none is found in this page, returns
+        // the first box of the next page.
+        QPointF reducedCoordPoint {point.x() / at.second.width(),
+                (point.y() - at.second.y()) / at.second.height()};
+        *boxIndex = 0;
+        for (PDFDocument::TextList::const_iterator box = boxes.begin();
+             box != boxes.end(); box++) {
+            /* Stop counting boxes down as soon as a box after reducedCoordPoint is found. */
+            if (box->first.y() > reducedCoordPoint.y() ||
+                (box->first.y() + box->first.height() > reducedCoordPoint.y() &&
+                 box->first.x() + box->first.width() > reducedCoordPoint.x())) {
+                return;
+            }
+            *boxIndex += 1;
+        }
+        *pageIndex += 1;
+        if (*pageIndex >= canvas->document()->pageCount())
+            *pageIndex = -1;
+        *boxIndex = 0;
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void PDFSelection::setStart(const QPointF &point)
+{
+    int pageIndex, boxIndex;
+    bool swap;
+
+    d->textBoxAtPoint(point, PDFSelection::Private::After, &pageIndex, &boxIndex);
+    if (pageIndex < 0 || boxIndex < 0)
+      return;
+
+    swap = (pageIndex > d->pageIndexStop
+            || (pageIndex == d->pageIndexStop && boxIndex > d->boxIndexStop));
+    if (swap) {
+        pageIndex = d->pageIndexStop;
+        boxIndex = d->boxIndexStop;
+        d->handleReversed = !d->handleReversed;
+        setStop(point);
+        if (pageIndex == d->pageIndexStop && boxIndex == d->boxIndexStop)
+            emit handle1Changed();
+    }
+    if (pageIndex == d->pageIndexStart && boxIndex == d->boxIndexStart) {
+        if (swap)
+            emit handle2Changed();
+        return;
+    }
+
+    const PDFDocument::TextList &boxes = d->canvas->document()->textBoxesAtPage(pageIndex);
+    QRectF box = boxes[boxIndex].first;
+
+    int nBoxes = d->sliceCount(pageIndex, boxIndex, d->pageIndexStart, d->boxIndexStart);
+    if (nBoxes > 0) {
+        beginInsertRows(QModelIndex(), 0, nBoxes - 1);
+        d->pageIndexStart = pageIndex;
+        d->boxIndexStart = boxIndex;
+        endInsertRows();
+    } else if (nBoxes < 0) {
+        beginRemoveRows(QModelIndex(), 0, -nBoxes - 1);
+        d->pageIndexStart = pageIndex;
+        d->boxIndexStart = boxIndex;
+        endRemoveRows();
+    }
+
+    d->start = QPointF(box.x(), box.y() + box.height() / 2.);
+    if (d->handleReversed)
+        emit handle2Changed();
+    else
+        emit handle1Changed();
+
+    emit countChanged();
+    emit textChanged();
+}
+
+QPointF PDFSelection::handle1() const
+{
+    if (!d->canvas ||
+        ((d->handleReversed) ? d->pageIndexStop : d->pageIndexStart) < 0) {
+        return QPointF();
+    }
+    
+    if (d->handleReversed)
+        return d->canvas->fromPageToItem(d->pageIndexStop, d->stop);
+    else
+        return d->canvas->fromPageToItem(d->pageIndexStart, d->start);
+}
+
+float PDFSelection::handle1Height() const
+{
+    if (d->handleReversed)
+        return d->canvas->fromPageToItem(d->pageIndexStop, rectAt(-1).second).height();
+    else
+        return d->canvas->fromPageToItem(d->pageIndexStart, rectAt(0).second).height();
+}
+
+void PDFSelection::setHandle1(const QPointF &point)
+{
+    if (d->handleReversed)
+        setStop(point);
+    else
+        setStart(point);
+}
+
+void PDFSelection::setStop(const QPointF &point)
+{
+    int pageIndex, boxIndex;
+    bool swap;
+  
+    d->textBoxAtPoint(point, PDFSelection::Private::Before, &pageIndex, &boxIndex);
+    if (pageIndex < 0 || boxIndex < 0)
+        return;
+
+    swap = (pageIndex < d->pageIndexStart
+            || (pageIndex == d->pageIndexStart && boxIndex < d->boxIndexStart));
+    if (swap) {
+        pageIndex = d->pageIndexStart;
+        boxIndex = d->boxIndexStart;
+        d->handleReversed = !d->handleReversed;
+        setStart(point);
+        if (pageIndex == d->pageIndexStart && boxIndex == d->boxIndexStart)
+            emit handle2Changed();
+    }
+    if (pageIndex == d->pageIndexStop && boxIndex == d->boxIndexStop) {
+        if (swap)
+            emit handle1Changed();
+        return;
+    }
+
+    const PDFDocument::TextList &boxes = d->canvas->document()->textBoxesAtPage(pageIndex);
+    QRectF box = boxes[boxIndex].first;
+
+    int count_ = count(); 
+    int nBoxes = d->sliceCount(d->pageIndexStop, d->boxIndexStop, pageIndex, boxIndex);
+    if (nBoxes > 0) {
+        beginInsertRows(QModelIndex(), count_, count_ + nBoxes - 1);
+        d->pageIndexStop = pageIndex;
+        d->boxIndexStop = boxIndex;
+        endInsertRows();
+    } else if (nBoxes < 0) {
+        beginRemoveRows(QModelIndex(), count_ + nBoxes, count_ - 1);
+        d->pageIndexStop = pageIndex;
+        d->boxIndexStop = boxIndex;
+        endRemoveRows();
+    }
+
+    d->stop = QPointF(box.x() + box.width(), box.y() + box.height() / 2.);
+    if (d->handleReversed)
+        emit handle1Changed();
+    else
+        emit handle2Changed();
+
+    emit countChanged();
+    emit textChanged();
+}
+
+QPointF PDFSelection::handle2() const
+{
+    if (!d->canvas ||
+        ((d->handleReversed) ? d->pageIndexStart : d->pageIndexStop) < 0) {
+        return QPointF();
+    }
+
+    if (d->handleReversed)
+        return d->canvas->fromPageToItem(d->pageIndexStart, d->start);
+    else
+        return d->canvas->fromPageToItem(d->pageIndexStop, d->stop);
+}
+
+float PDFSelection::handle2Height() const
+{
+    if (d->handleReversed)
+        return d->canvas->fromPageToItem(d->pageIndexStart, rectAt(0).second).height();
+    else
+        return d->canvas->fromPageToItem(d->pageIndexStop, rectAt(-1).second).height();
+}
+
+void PDFSelection::setHandle2(const QPointF &point)
+{
+    if (d->handleReversed)
+        setStart(point);
+    else
+        setStop(point);
+}
+
+void PDFSelection::selectAt(const QPointF &point)
+{
+    if (d->pageIndexStart >= 0 && d->boxIndexStart >= 0
+        && d->pageIndexStop >= 0 && d->boxIndexStop >= 0) {
+        unselect();
+    }
+
+    int pageIndex, boxIndex;
+    d->textBoxAtPoint(point, PDFSelection::Private::At, &pageIndex, &boxIndex);
+    if (pageIndex < 0 || boxIndex < 0)
+        return;
+
+    const PDFDocument::TextList &boxes = d->canvas->document()->textBoxesAtPage(pageIndex);
+    QRectF box = boxes[boxIndex].first;
+
+    beginInsertRows(QModelIndex(), 0, 0);
+    d->pageIndexStart = pageIndex;
+    d->boxIndexStart = boxIndex;
+    d->pageIndexStop = pageIndex;
+    d->boxIndexStop = boxIndex;
+    endInsertRows();
+
+    d->handleReversed = false;
+
+    d->start = QPointF(box.x(), box.y() + box.height() / 2.);
+    emit handle1Changed();
+    d->stop = QPointF(box.x() + box.width(), box.y() + box.height() / 2.);
+    emit handle2Changed();
+
+    emit countChanged();
+    emit textChanged();
+}
+
+void PDFSelection::unselect()
+{
+    beginResetModel();
+    d->pageIndexStart = d->pageIndexStop = -1;
+    d->boxIndexStart = d->boxIndexStop = -1;
+    endResetModel();
+    emit countChanged();
+    emit textChanged();
+}
+
+void PDFSelection::onLayoutChanged()
+{
+    int nselection = count();
+    if (nselection == 0)
+        return;
+
+    emit handle1Changed();
+    emit handle2Changed();
+    emit dataChanged(createIndex(0, 0), createIndex(nselection - 1, 0),
+                     QVector<int>{Rect});
+}
+
+QString PDFSelection::text() const
+{
+    QString out;
+
+    if (d->pageIndexStart < 0 || d->pageIndexStop < 0 ||
+        d->boxIndexStart < 0 || d->boxIndexStop < 0) {
+        return out;
+    }
+
+    if (!d->canvas)
+        return out;
+    PDFDocument *doc = d->canvas->document();
+    if (!doc)
+        return out;
+    
+    int i, j;
+    for (i = d->pageIndexStart; i <= d->pageIndexStop; i++) {
+        const PDFDocument::TextList &boxes = doc->textBoxesAtPage(i);
+        for (j = ((i == d->pageIndexStart) ? d->boxIndexStart : 0);
+             j < ((i == d->pageIndexStop) ? d->boxIndexStop : boxes.length());
+             j++) {
+            Poppler::TextBox *tbox = boxes.value(j).second;
+            out += tbox->text() + (tbox->hasSpaceAfter() ? " " : "");
+        }
+    }
+    const PDFDocument::TextList &boxes = doc->textBoxesAtPage(d->pageIndexStop);
+    out += boxes.value(d->boxIndexStop).second->text();
+    return out;
+}

--- a/pdf/pdfselection.h
+++ b/pdf/pdfselection.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef PDFSELECTION_H
+#define PDFSELECTION_H
+
+#include <QtCore/QAbstractListModel>
+
+#include "pdfcanvas.h"
+
+class PDFSelection : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(PDFCanvas* canvas READ canvas WRITE setCanvas NOTIFY canvasChanged)
+    Q_PROPERTY(QPointF handle1 READ handle1 WRITE setHandle1 NOTIFY handle1Changed)
+    Q_PROPERTY(QPointF handle2 READ handle2 WRITE setHandle2 NOTIFY handle2Changed)
+    Q_PROPERTY(float handle1Height READ handle1Height NOTIFY handle1Changed)
+    Q_PROPERTY(float handle2Height READ handle2Height NOTIFY handle2Changed)
+    Q_PROPERTY(QString text READ text NOTIFY textChanged)
+    Q_PROPERTY(float wiggle READ wiggle WRITE setWiggle NOTIFY wiggleChanged)
+
+public:
+    enum PDFSelectionRoles {
+        Rect = Qt::UserRole + 1,
+        Text
+    };
+    explicit PDFSelection(QObject *parent = 0);
+    virtual ~PDFSelection();
+
+    virtual QVariant data(const QModelIndex &index, int role) const;
+    virtual int rowCount(const QModelIndex &parent) const;
+    virtual QHash<int, QByteArray> roleNames() const;
+
+    QPair<int, QRectF> rectAt(int index) const;
+
+    int count() const;
+    PDFCanvas* canvas() const;
+    void setCanvas(PDFCanvas *newCanvas);
+    float wiggle() const;
+    void setWiggle(float newValue);
+
+    /**
+     * Change current selection to match the word that is at point in canvas coordinates.
+     * If there is no word at point, the selection is invalidated (ie. count is set to
+     * zero).
+     */
+    Q_INVOKABLE void selectAt(const QPointF &point);
+    Q_INVOKABLE void unselect();
+
+    /**
+     * Return a point for the start handle of the selection in canvas coordinates.
+     * This handle can be dragged later and become the stop handle.
+     */
+    QPointF handle1() const;
+    float handle1Height() const;
+    /**
+     * Change the start/stop of the selection to the start/end of the word at point.
+     * point is given in canvas coordinates. If there is no word at point,
+     * the selection is left unchanged.
+     */
+    void setHandle1(const QPointF &point);
+
+    /**
+     * Return a point for the stop handle of the selection in canvas coordinates.
+     * This handle can later be dragged to become the start handle.
+     */
+    QPointF handle2() const;
+    float handle2Height() const;
+    /**
+     * Change the stop of the selection to the end of the word at point.
+     * point is given in canvas coordinates. If there is no word at point,
+     * the selection is left unchanged.
+     */
+    void setHandle2(const QPointF &point);
+
+    QString text() const;
+
+Q_SIGNALS:
+    void countChanged();
+    void canvasChanged();
+    void handle1Changed();
+    void handle2Changed();
+    void textChanged();
+    void wiggleChanged();
+
+private:
+    class Private;
+    Private * const d;
+
+    void setStart(const QPointF &point);
+    void setStop(const QPointF &point);
+
+    void onLayoutChanged();
+};
+
+#endif // PDFSELECTION_H

--- a/pdf/sailfishofficepdfplugin.cpp
+++ b/pdf/sailfishofficepdfplugin.cpp
@@ -21,6 +21,7 @@
 #include "pdfdocument.h"
 #include "pdfcanvas.h"
 #include "pdflinkarea.h"
+#include "pdfselection.h"
 
 SailfishOfficePDFPlugin::SailfishOfficePDFPlugin(QObject *parent)
     : QQmlExtensionPlugin(parent)
@@ -33,4 +34,5 @@ void SailfishOfficePDFPlugin::registerTypes(const char *uri)
     qmlRegisterType<PDFDocument>(uri, 1, 0, "Document");
     qmlRegisterType<PDFCanvas>(uri, 1, 0, "Canvas");
     qmlRegisterType<PDFLinkArea>(uri, 1, 0, "LinkArea");
+    qmlRegisterType<PDFSelection>(uri, 1, 0, "Selection");
 }

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -18,6 +18,7 @@ install(FILES
     PDFView.qml
     PDFSelectionView.qml
     PDFSelectionHandle.qml
+    PDFSelectionDrag.qml
     PDFContextMenu.qml
     PDFStorage.js
     PresentationPage.qml

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -16,6 +16,8 @@ install(FILES
     PDFDocumentPage.qml
     PDFDocumentToCPage.qml
     PDFView.qml
+    PDFSelectionView.qml
+    PDFSelectionHandle.qml
     PDFContextMenu.qml
     PDFStorage.js
     PresentationPage.qml

--- a/plugin/PDFSelectionDrag.qml
+++ b/plugin/PDFSelectionDrag.qml
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2016 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+MouseArea {
+    id: root
+
+    property point handle
+    property Item flickable
+
+    property real _contentY0
+    property real _contentY: flickable !== undefined ? flickable.contentY : 0.
+    property real _dragX0
+    property real _dragY0
+    property real dragX
+    property real dragY
+
+    signal dragged(point at)
+
+    width: Theme.itemSizeSmall
+    height: width
+
+    enabled: visible
+    preventStealing: true
+    onPressed: {
+        _dragX0 = mouseX
+        _dragY0 = mouseY
+        _contentY0 = flickable !== undefined ? flickable.contentY : 0.
+    }
+    onReleased: {
+        dragX = 0
+        dragY = 0
+    }
+
+    Binding {
+        target: root
+        property: "x"
+        value: root.handle.x - root.width / 2
+        when: !root.pressed
+    }
+    Binding {
+        target: root
+        property: "y"
+        value: root.handle.y - root.height / 2
+        when: !root.pressed
+    }
+    onMouseXChanged: dragX = pressed ? mouseX - _dragX0 : 0.
+    onMouseYChanged: dragY = pressed ? mouseY - _dragY0 - _contentY + _contentY0 : 0.
+    onDragXChanged: {
+        if (pressed) {
+            root.dragged(Qt.point(x + width / 2 + dragX, y + height / 2 + dragY))
+        }
+    }
+    onDragYChanged: {
+        if (pressed) {
+            root.dragged(Qt.point(x + width / 2 + dragX, y + height / 2 + dragY))
+        }
+    }
+
+    Rectangle {
+        x: (root.width - width) / 2 + dragX
+        y: (root.height - height) / 2 + dragY
+        width: Theme.iconSizeSmall / 2 * 1.414
+        height: width
+        visible: opacity > 0.
+        opacity: root.pressed ? 0.25 : 0.
+        Behavior on opacity { FadeAnimation {} }
+        radius: width / 2
+        color: Qt.rgba(1. - Theme.highlightDimmerColor.r,
+                       1. - Theme.highlightDimmerColor.g,
+                       1. - Theme.highlightDimmerColor.b,
+                       1.)
+        Rectangle {
+            anchors.centerIn: parent
+            color: Theme.highlightDimmerColor
+            width: Theme.iconSizeSmall / 2
+            height: width
+            radius: width / 2
+        }
+    }
+}

--- a/plugin/PDFSelectionHandle.qml
+++ b/plugin/PDFSelectionHandle.qml
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2016 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+Item {
+    id: root
+
+    property bool press
+    property point handle
+    property alias attachX: appearingMove.from
+
+    signal dragged(point at)
+
+    width: Theme.itemSizeSmall
+    height: width
+
+    NumberAnimation {
+        id: appearingMove
+        duration: 200
+        easing.type: Easing.InOutCubic
+        target: root
+        property: "x"
+        to: root.handle.x - root.width / 2
+    }
+    onVisibleChanged: {
+        if (visible) {
+            appearingMove.start()
+        }
+    }
+
+    Binding {
+        target: root
+        property: "x"
+        value: root.handle.x - root.width / 2
+        when: !mouseArea.drag.active
+    }
+    Binding {
+        target: root
+        property: "y"
+        value: root.handle.y - root.height / 2
+        when: !mouseArea.drag.active
+    }
+    onXChanged: {
+        if (mouseArea.drag.active) {
+            root.dragged(Qt.point(x + width / 2, y + height / 2))
+        }
+    }
+    onYChanged: {
+        if (mouseArea.drag.active) {
+            root.dragged(Qt.point(x + width / 2, y + height / 2))
+        }
+    }
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        enabled: root.visible
+        preventStealing: true
+        onPressed: root.press = true
+        onReleased: root.press = false
+        drag.target: parent
+    }
+    Rectangle {
+        anchors.centerIn: parent
+        opacity: 0.5
+        color: Theme.highlightDimmerColor
+        width: Theme.paddingMedium
+        height: width
+        radius: width / 2
+    }
+}

--- a/plugin/PDFSelectionHandle.qml
+++ b/plugin/PDFSelectionHandle.qml
@@ -19,69 +19,63 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 
-Item {
+Rectangle {
     id: root
 
-    property bool press
+    property alias attachX: translationMove.from
     property point handle
-    property alias attachX: appearingMove.from
+    property bool dragged
+    property real dragHeight
 
-    signal dragged(point at)
-
-    width: Theme.itemSizeSmall
+    x: handle.x - width / 2
+    y: handle.y - height / 2
+    opacity: 0.5
+    color: Theme.highlightDimmerColor
+    width: Math.round(Theme.iconSizeSmall / 4) * 2 // ensure even number
     height: width
+    radius: width / 2
 
-    NumberAnimation {
-        id: appearingMove
-        duration: 200
-        easing.type: Easing.InOutCubic
-        target: root
-        property: "x"
-        to: root.handle.x - root.width / 2
+    states: State {
+        when: dragged
+        name: "dragged"
+        PropertyChanges {
+            target: root
+            width: Theme.paddingSmall / 2
+            height: dragHeight
+            radius: 0
+        }
     }
+
+    transitions: Transition {
+        to: "dragged"
+        reversible: true
+        SequentialAnimation {
+            NumberAnimation { property: "width"; duration: 100 }
+            PropertyAction { property: "radius" }
+            NumberAnimation { property: "height"; duration: 100 }
+        }
+    }
+
+    ParallelAnimation {
+        id: appearingMove
+        FadeAnimation {
+            target: root
+            from: 0
+            to: 0.5
+        }
+        NumberAnimation {
+            id: translationMove
+            duration: 200
+            easing.type: Easing.InOutQuad
+            target: root
+            property: "x"
+            to: root.x
+        }
+    }
+
     onVisibleChanged: {
         if (visible) {
             appearingMove.start()
         }
-    }
-
-    Binding {
-        target: root
-        property: "x"
-        value: root.handle.x - root.width / 2
-        when: !mouseArea.drag.active
-    }
-    Binding {
-        target: root
-        property: "y"
-        value: root.handle.y - root.height / 2
-        when: !mouseArea.drag.active
-    }
-    onXChanged: {
-        if (mouseArea.drag.active) {
-            root.dragged(Qt.point(x + width / 2, y + height / 2))
-        }
-    }
-    onYChanged: {
-        if (mouseArea.drag.active) {
-            root.dragged(Qt.point(x + width / 2, y + height / 2))
-        }
-    }
-    MouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        enabled: root.visible
-        preventStealing: true
-        onPressed: root.press = true
-        onReleased: root.press = false
-        drag.target: parent
-    }
-    Rectangle {
-        anchors.centerIn: parent
-        opacity: 0.5
-        color: Theme.highlightDimmerColor
-        width: Theme.paddingMedium
-        height: width
-        radius: width / 2
     }
 }

--- a/plugin/PDFSelectionView.qml
+++ b/plugin/PDFSelectionView.qml
@@ -22,15 +22,11 @@ import Sailfish.Silica 1.0
 Repeater {
     id: root
 
-    property alias startAttachX: handle1.attachX
-    property alias stopAttachX: handle2.attachX
-    property bool dragging: handle1.press || handle2.press
+    property Item flickable
+    property alias dragHandle1: handle1.dragged
+    property alias dragHandle2: handle2.dragged
 
     visible: (model !== undefined && model.count > 0)
-
-    /* Copy text to clipboard on first selection and when stop dragging. */
-    onVisibleChanged: if (visible) Clipboard.text = model.text
-    onDraggingChanged: if (!dragging) Clipboard.text = model.text
 
     delegate: Rectangle {
         opacity: 0.5
@@ -44,13 +40,19 @@ Repeater {
     children: [
         PDFSelectionHandle {
             id: handle1
+            attachX: root.flickable !== undefined
+                     ? flickable.contentX
+                     : handle.x - Theme.itemSizeExtraLarge
             handle: root.model.handle1
-            onDragged: root.model.handle1 = at
-        }
-        , PDFSelectionHandle {
+            dragHeight: root.model.handle1Height
+        },
+        PDFSelectionHandle {
             id: handle2
+            attachX: root.flickable !== undefined
+                     ? flickable.contentX + flickable.width
+                     : handle.x + Theme.itemSizeExtraLarge
             handle: root.model.handle2
-            onDragged: root.model.handle2 = at
+            dragHeight: root.model.handle2Height
         }
     ]
 }

--- a/plugin/PDFSelectionView.qml
+++ b/plugin/PDFSelectionView.qml
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016 Caliste Damien.
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+Repeater {
+    id: root
+
+    property alias startAttachX: handle1.attachX
+    property alias stopAttachX: handle2.attachX
+    property bool dragging: handle1.press || handle2.press
+
+    visible: (model !== undefined && model.count > 0)
+
+    /* Copy text to clipboard on first selection and when stop dragging. */
+    onVisibleChanged: if (visible) Clipboard.text = model.text
+    onDraggingChanged: if (!dragging) Clipboard.text = model.text
+
+    delegate: Rectangle {
+        opacity: 0.5
+        color: Theme.highlightColor
+        x: rect.x
+        y: rect.y
+        width: rect.width
+        height: rect.height
+    }
+
+    children: [
+        PDFSelectionHandle {
+            id: handle1
+            handle: root.model.handle1
+            onDragged: root.model.handle1 = at
+        }
+        , PDFSelectionHandle {
+            id: handle2
+            handle: root.model.handle2
+            onDragged: root.model.handle2 = at
+        }
+    ]
+}

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -115,7 +115,8 @@ SilicaFlickable {
         }
     }
     NumberAnimation {
-        id: dragOffset
+        id: selectionOffset
+        property real start
         duration: 200
         easing.type: Easing.InOutCubic
         target: base
@@ -135,8 +136,39 @@ SilicaFlickable {
 
     PDF.Selection {
         id: selection
+        
+        property bool dragging: drag1.pressed || drag2.pressed
+        property bool selected: count > 0
+
         canvas: pdfCanvas
         wiggle: Theme.itemSizeSmall / 2
+        
+        onDraggingChanged: {
+            if (dragging) {
+                if (!selectionOffset.running)
+                    selectionOffset.start = base.contentY
+
+                // Limit offset when being at the bottom of the view.
+                selectionOffset.to = selectionOffset.start +
+                    Math.min(Theme.itemSizeSmall,
+                             Math.max(0, base.itemHeight - base.height - base.contentY))
+                // Limit offset when being at the top of screen
+                selectionOffset.to =
+                    Math.max(base.contentY,
+                             Math.min(selectionOffset.to,
+                                      (drag1.pressed ? handle1.y : handle2.y)
+                                      - Theme.itemSizeSmall / 2)
+                            )
+            } else {
+                selectionOffset.to = selectionOffset.start
+            }
+            selectionOffset.restart()
+            
+            // Copy selection to clipboard when dragging finishes
+            if (!dragging) Clipboard.text = text
+        }
+        // Copy selection to clipboard on first selection
+        onSelectedChanged: if (selected) Clipboard.text = text
     }
 
     PDF.Canvas {
@@ -212,20 +244,25 @@ SilicaFlickable {
         }
 
         PDFSelectionView {
-            id: selectionView
             model: selection
-            startAttachX: 0
-            stopAttachX: base.width
+            flickable: base
+            dragHandle1: drag1.pressed
+            dragHandle2: drag2.pressed
             onVisibleChanged: if (visible && _feedbackEffect) _feedbackEffect.play()
-            onDraggingChanged: {
-                if (dragging) {
-                    dragOffset.to = base.contentY + Theme.itemSizeSmall
-                    dragOffset.start()
-                } else {
-                    dragOffset.to = base.contentY - Theme.itemSizeSmall
-                    dragOffset.start()
-                }
-            }
+        }
+        PDFSelectionDrag {
+            id: drag1
+            visible: selection.selected
+            flickable: base
+            handle: selection.handle1
+            onDragged: selection.handle1 = at
+        }
+        PDFSelectionDrag {
+            id: drag2
+            visible: selection.selected
+            flickable: base
+            handle: selection.handle2
+            onDragged: selection.handle2 = at
         }
     }
 


### PR DESCRIPTION
This PR introduces text selection in PDF documents. It is made of four commits:
* first commit makes available in PDFDocument class the list of text boxes for each pages as returned by Poppler.
* second commit implements a QAbstractModelList to expose a portion of the previous list of text boxes for each page. It introduces a method to retrieve a text box at a given point and methods to change the start and stop boundaries for text selection.
* third commits adds a longPress signal to the PDFLinkArea object.
* fourth commit uses all the previous ones to implement the user interface for text selection.

The way text is selected is as followed:
* long press on a word, the word is highlighted and two handles appears to both ends;
* tap and drag a handle (start or stop) to adjust the selection; when a handle is tapped, the document is zoomed and a bit shifted to allow to see where the handle is moved.
* changing selection automatically copy the text to clipboard.
* unselect by long press on an area without text.

It took me a lot of time to create this PR (first commit was done on October 2015), particularly for the UI part (dragging, not interfering with flick…). But this is essential for a more ambicious PR implementing PDF annotations, so one can select a portion of text to annotate (comment or highlight). Having the annotation working (using Poppler of course) would be a great addition.

But first, let's discuss the selection PR, trying to improve this first (not really) proposition.