### PR TITLE
[office] Fix zero page PDF documents.

### DIFF
--- a/pdf/pdfcanvas.cpp
+++ b/pdf/pdfcanvas.cpp
@@ -254,7 +254,7 @@ void PDFCanvas::setPagePlaceholderColor(const QColor &color)
 void PDFCanvas::layout()
 {
     if (d->pageSizes.count() == 0) {
-        if (d->document->isLoaded() && !d->pageSizeRequested) {
+        if (d->document->isLoaded() && d->pageCount > 0 && !d->pageSizeRequested) {
             d->document->requestPageSizes();
             d->pageSizeRequested = true;
         }

--- a/pdf/pdfrenderthread.cpp
+++ b/pdf/pdfrenderthread.cpp
@@ -335,7 +335,7 @@ void PDFRenderThreadQueue::processPendingJob()
             }
     
             d->document = dj->m_document;
-            if (d->document) {
+            if (d->document && d->document->numPages() > 0) {
                 if (!d->document->isLocked()) {
                     d->tocModel = new PDFTocModel(d->document);
                     d->rescanDocumentLinks();


### PR DESCRIPTION
When testing the 1310 pages PDF reference document to look for slowing factors, it happens that this PDF file cannot be opened with Poppler 0.24.5 (which is currently on my phone), it gives some errors and reports to have no page.

I notice so that zero-page document handling is broken (infinite loop requesting page size + no way to go back to document list). This PR should fix the two issues by setting the failure flag to doculment when the document has no page.