### PR TITLE
Make search in PDF cancellable (and not using the rendering thread)

### DIFF
--- a/pdf/pdfdocument.cpp
+++ b/pdf/pdfdocument.cpp
@@ -200,7 +200,23 @@ void PDFDocument::search(const QString &search, uint startPage)
         d->searching = true;
         emit searchingChanged();
         d->thread->search(search, startPage);
+    } else {
+        cancelSearch();
     }
+}
+
+void PDFDocument::cancelSearch()
+{
+    if (d->searchModel != nullptr) {
+        delete d->searchModel;
+        d->searchModel = nullptr;
+        emit searchModelChanged();
+    }
+    if (d->searching) {
+        d->searching = false;
+        emit searchingChanged();
+    }
+    d->thread->cancelSearch();
 }
 
 void PDFDocument::loadFinished()

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -76,6 +76,7 @@ public Q_SLOTS:
     void cancelPageRequest(int index);
     void requestPageSizes();
     void search(const QString &search, uint startPage = 0);
+    void searchFinished(const QList<QPair<int, QRectF>> &matches);
     void loadFinished();
     void jobFinished(PDFJob *job);
 

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -76,6 +76,7 @@ public Q_SLOTS:
     void cancelPageRequest(int index);
     void requestPageSizes();
     void search(const QString &search, uint startPage = 0);
+    void cancelSearch();
     void searchFinished(const QList<QPair<int, QRectF>> &matches);
     void loadFinished();
     void jobFinished(PDFJob *job);

--- a/pdf/pdfjob.cpp
+++ b/pdf/pdfjob.cpp
@@ -87,39 +87,3 @@ void PageSizesJob::run()
         delete page;
     }
 }
-
-SearchDocumentJob::SearchDocumentJob(const QString &search, uint page)
-  : PDFJob(PDFJob::SearchDocumentJob), m_search(search), startPage(page)
-{
-}
-
-void SearchDocumentJob::run()
-{
-    Q_ASSERT(m_document);
-
-    for (int i = 0; i < m_document->numPages(); ++i) {
-        int ipage = (startPage + i) % m_document->numPages();
-        Poppler::Page *page = m_document->page(ipage);
-    
-        double sLeft, sTop, sRight, sBottom;
-        float scaleW = 1.f / page->pageSizeF().width();
-        float scaleH = 1.f / page->pageSizeF().height();
-        bool found;
-        found = page->search(m_search, sLeft, sTop, sRight, sBottom,
-                             Poppler::Page::FromTop,
-                             Poppler::Page::IgnoreCase);
-        while (found) {
-            QRectF result;
-            result.setLeft(sLeft * scaleW);
-            result.setTop(sTop * scaleH);
-            result.setRight(sRight * scaleW);
-            result.setBottom(sBottom * scaleH);
-            m_matches.append(QPair<int, QRectF>(ipage, result));
-            found = page->search(m_search, sLeft, sTop, sRight, sBottom,
-                                 Poppler::Page::NextResult,
-                                 Poppler::Page::IgnoreCase);
-        }
-
-        delete page;
-    }
-}

--- a/pdf/pdfjob.h
+++ b/pdf/pdfjob.h
@@ -111,20 +111,5 @@ public:
     QList<QSizeF> m_pageSizes;
 };
 
-class SearchDocumentJob : public PDFJob
-{
-    Q_OBJECT
-public:
-    SearchDocumentJob(const QString& search, uint page);
-
-    virtual void run();
-
-    QList<QPair<int, QRectF>> m_matches;
-
-private:
-    QString m_search;
-    uint startPage;
-};
-
 
 #endif // PDFJOB_H

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -44,6 +44,7 @@ public:
     bool isLocked() const;
     QMultiMap<int, QPair<QRectF, QUrl> > linkTargets() const;
     QList<QPair<QRectF, Poppler::TextBox*> > textBoxesAtPage(int page);
+    void search(const QString &search, uint startPage);
 
     void queueJob(PDFJob *job);
     void cancelRenderJob(int index);
@@ -52,7 +53,11 @@ public:
 Q_SIGNALS:
     void loadFinished();
     void jobFinished(PDFJob *job);
+    void searchFinished(const QList<QPair<int, QRectF>> &matches);
 
+private Q_SLOTS:
+    void onSearchFinished();
+    
 private:
     friend class PDFRenderThreadPrivate;
 

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -45,6 +45,7 @@ public:
     QMultiMap<int, QPair<QRectF, QUrl> > linkTargets() const;
     QList<QPair<QRectF, Poppler::TextBox*> > textBoxesAtPage(int page);
     void search(const QString &search, uint startPage);
+    void cancelSearch();
 
     void queueJob(PDFJob *job);
     void cancelRenderJob(int index);

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -159,7 +159,11 @@ DocumentPage {
                                      - (searchNext.visible ? searchNext.width : 0)
                 anchors.verticalCenter: parent.verticalCenter
 
-                enabled: !pdfDocument.searching
+                onFocusChanged: {
+                    if (focus && pdfDocument.searching) {
+                        pdfDocument.cancelSearch()
+                    }
+                }
 
                 inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase | Qt.ImhNoPredictiveText
 


### PR DESCRIPTION
Initial implementation of search capability in PDF document is using the job queue that is created to load and render PDF documents. That was done for reasons of simplicity and reuse of existing code. But it has three main drawbacks:
* it is using the rendering thread, so a long search postpone any new rendering job (*i.e.* scrolling while searching does not update the view);
* it is not easily cancellable without adding cancellation in PDFJob class that has no sense for other purposes of PDFJob (except loading maybe). So searches in long documents can last for minutes;
* it can not without additional modifications report search progress.

The present PR corrects the first two points by introducing a new ```SearchThread``` class that is dedicated for search. Like that any code specific to search (cancel or progress report) can be implemented there without poluting the rendering thread machinery. Nevertheless its code still resides in ```pdfrenderthread.cpp``` since it is there that the ```Poppler::Document``` is, but if you think it's better, I can create a new ```pdfsearchthread.cpp``` file.

The third point, implying to report progress, can be implemeted later by signaling every ten pages or so, that the list ```m_matches``` has been expanded and modify the search model accordingly.