### PR TITLE
[office] Postpone texture deletion, avoid crash on quit with busy running.

### DIFF
--- a/pdf/pdfcanvas.cpp
+++ b/pdf/pdfcanvas.cpp
@@ -127,7 +127,7 @@ PDFCanvas::~PDFCanvas()
 {
     for (int i = 0; i < d->pageCount; ++i) {
         PDFPage &page = d->pages[i];
-        delete page.texture;
+        page.texture->deleteLater();
         page.texture = nullptr;
     }
 


### PR DESCRIPTION
Should correct issue #83 . The cullprit was the texture that was delete as soon as the PDFCanvas object was delete while they may be used a bit longer by the render thread.

Seems to work, but should be tested further.