### PR TITLE
Design update of the toolbar

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -28,6 +28,7 @@ install(FILES
     TextDocumentPage.qml
     TextDocumentToCPage.qml
     ZoomableThumbnail.qml
+    SearchBarItem.qml
     ToolBar.qml
     DetailsPage.qml
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/qt5/qml/Sailfish/Office

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -121,19 +121,30 @@ DocumentPage {
         anchors.top: view.bottom
         flickable: view
         forceHidden: base.open || pdfDocument.failure || pdfDocument.locked
-        autoShowHide: search.text.length == 0 && !search.activeFocus
+        autoShowHide: !row.active
 
         // Toolbar contain.
         Row {
             id: row
+            property bool active: pageCount.highlighted
+                                  || search.highlighted
+                                  || !search.iconized
             property real itemWidth: toolbar.width / children.length
             height: parent.height
-            x: search.activeFocus ? -pageCount.width : 0
 
-            Behavior on x {
-                NumberAnimation { easing.type: Easing.InOutQuad; duration: 400 }
+            SearchBarItem {
+                id: search
+                width: toolbar.width
+                iconizedWidth: row.itemWidth
+                height: parent.height
+
+                modelCount: pdfDocument.searchModel ? pdfDocument.searchModel.count : -1
+
+                onRequestSearch: pdfDocument.search(text, view.currentPage - 1)
+                onRequestPreviousMatch: view.prevSearchMatch()
+                onRequestNextMatch: view.nextSearchMatch()
+                onRequestCancel: pdfDocument.cancelSearch()
             }
-
             BackgroundItem {
                 id: pageCount
                 width: row.itemWidth
@@ -145,66 +156,6 @@ DocumentPage {
                     text: view.currentPage + " | " + view.document.pageCount
                 }
                 onClicked: base.pushAttachedPage()
-            }
-            SearchField {
-                id: search
-                width: activeFocus ? toolbar.width
-                                   : toolbar.width - pageCount.width
-                                     - (searchPrev.visible ? searchPrev.width : 0)
-                                     - (searchNext.visible ? searchNext.width : 0)
-                anchors.verticalCenter: parent.verticalCenter
-
-                onFocusChanged: {
-                    if (focus && pdfDocument.searching) {
-                        pdfDocument.cancelSearch()
-                    }
-                }
-
-                inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase | Qt.ImhNoPredictiveText
-
-                EnterKey.iconSource: text != "" ? "image://theme/icon-m-enter-accept"
-                                                : "image://theme/icon-m-enter-close"
-                EnterKey.onClicked: {
-                    focus = false
-                    pdfDocument.search(text, view.currentPage - 1)
-                }
-
-                Behavior on width {
-                    NumberAnimation { easing.type: Easing.InOutQuad; duration: 400 }
-                }
-            }
-            IconButton {
-                id: searchPrev
-                anchors.verticalCenter: parent.verticalCenter
-                icon.source: "image://theme/icon-m-left"
-                visible: pdfDocument.searchModel && pdfDocument.searchModel.count > 0
-                onClicked: view.prevSearchMatch()
-            }
-            IconButton {
-                id: searchNext
-                anchors.verticalCenter: parent.verticalCenter
-                icon.source: "image://theme/icon-m-right"
-                visible: pdfDocument.searchModel && pdfDocument.searchModel.count > 0
-                onClicked: view.nextSearchMatch()
-            }
-        }
-        // Additional information
-        Label {
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.bottom: parent.bottom
-            
-            opacity: pdfDocument.searchModel && !search.activeFocus ? 1. : 0.
-            visible: opacity > 0.
-            text: pdfDocument.searchModel && pdfDocument.searchModel.count > 0
-                  ? //% "%n item(s) found"
-                    qsTrId("sailfish-office-lb-%n-matches", pdfDocument.searchModel.count)
-                  : //% "no matching found"
-                    qsTrId("sailfish-office-lb-no-matches")
-            font.pixelSize: Theme.fontSizeSmall
-            color: Theme.secondaryHighlightColor
-
-            Behavior on opacity {
-                FadeAnimation {}
             }
         }
     }

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -126,6 +126,7 @@ DocumentPage {
         // Toolbar contain.
         Row {
             id: row
+            property real itemWidth: toolbar.width / children.length
             height: parent.height
             x: search.activeFocus ? -pageCount.width : 0
 
@@ -133,23 +134,17 @@ DocumentPage {
                 NumberAnimation { easing.type: Easing.InOutQuad; duration: 400 }
             }
 
-            IconButton {
+            BackgroundItem {
                 id: pageCount
-                anchors.verticalCenter: parent.verticalCenter
-                width: icon.width + pageLabel.width
+                width: row.itemWidth
                 height: parent.height
-                icon.source: "image://theme/icon-m-document" + (highlighted ? "?" + Theme.highlightColor : "")
-                icon.anchors.centerIn: undefined
-                icon.anchors.left: pageCount.left
-                icon.anchors.verticalCenter: pageCount.verticalCenter
-                onClicked: base.pushAttachedPage()
                 Label {
                     id: pageLabel
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.right: parent.right
+                    anchors.centerIn: parent
                     color: pageCount.highlighted ? Theme.highlightColor : Theme.primaryColor
-                    text: view.currentPage + " / " + view.document.pageCount
+                    text: view.currentPage + " | " + view.document.pageCount
                 }
+                onClicked: base.pushAttachedPage()
             }
             SearchField {
                 id: search

--- a/plugin/SearchBarItem.qml
+++ b/plugin/SearchBarItem.qml
@@ -1,0 +1,241 @@
+/****************************************************************************************
+**
+** Copyright (C) 2013-2016 Jolla Ltd., Damien Caliste
+** Contact: Raine Makelainen <raine.makelainen@jollamobile.com>
+** Contact: Damien Caliste <dcaliste@free.fr>
+** All rights reserved.
+**
+** This file is part of Sailfish Office package and is a modified
+** version of SearchField.qml from Sailfish Silica package to add
+** next and previous button, modify the clear button action to support
+** cancellation and also introduce a new iconized state.
+**
+** You may use this file under the terms of BSD license as follows:
+**
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are met:
+**     * Redistributions of source code must retain the above copyright
+**       notice, this list of conditions and the following disclaimer.
+**     * Redistributions in binary form must reproduce the above copyright
+**       notice, this list of conditions and the following disclaimer in the
+**       documentation and/or other materials provided with the distribution.
+**     * Neither the name of the Jolla Ltd nor the
+**       names of its contributors may be used to endorse or promote products
+**       derived from this software without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+** ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+** WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+** ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+** (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+** LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+** ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+** SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+****************************************************************************************/
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+BackgroundItem {
+    id: root
+
+    property alias iconized: searchField.iconized
+    property alias modelCount: searchField.modelCount
+    property real iconizedWidth
+
+    signal requestSearch(string text)
+    signal requestPreviousMatch()
+    signal requestNextMatch()
+    signal requestCancel()
+
+    onClicked: searchField.iconized = false
+
+    states: [State {
+                 name: "extended"
+                 when: !searchField.iconized
+                 PropertyChanges {
+                     target: searchField
+                     _margin: 0.
+                 }
+             },
+             State {
+                 name: "iconized"
+                 when: searchField.iconized
+                 PropertyChanges {
+                     target: root
+                     width: iconizedWidth
+                 }
+             }]
+    transitions: Transition {
+        NumberAnimation {
+            properties: "_margin, width"
+            easing.type: Easing.InOutQuad
+            duration: 400
+        }
+    }
+    highlighted: down || searchIcon.down
+
+    TextField {
+        id: searchField
+
+        property bool iconized: true
+        property int modelCount: -1
+
+        property real _prevNextWidth: modelCount > 0 ? (Theme.itemSizeSmall + Theme.paddingMedium)*2 : 0.
+        implicitWidth: !iconized ? _editor.implicitWidth + Theme.paddingSmall
+                                   + Theme.itemSizeSmall*2  // width of two icons
+                                   + _prevNextWidth // width of prev / next icons
+                                 : Theme.itemSizeSmall
+        height: Math.max(Theme.itemSizeMedium, _editor.height + Theme.paddingMedium + Theme.paddingSmall)
+
+        property real _margin: Math.max((root.iconizedWidth - Theme.itemSizeSmall) / 2., 0.)
+        anchors {
+            verticalCenter: parent.verticalCenter
+            left: parent.left
+            right: parent.right
+            leftMargin: _margin
+            rightMargin: _margin
+        }
+
+        focusOutBehavior: FocusBehavior.ClearPageFocus
+        font {
+            pixelSize: Theme.fontSizeLarge
+            family: Theme.fontFamilyHeading
+        }
+
+        textLeftMargin: Theme.itemSizeSmall + Theme.paddingMedium + Theme.horizontalPageMargin - Theme.paddingLarge
+        textRightMargin: Theme.itemSizeSmall + Theme.paddingMedium + Theme.horizontalPageMargin - Theme.paddingLarge + _prevNextWidth
+        textTopMargin: labelVisible ? Theme.paddingSmall : (height/2 - _editor.implicitHeight/2)
+        labelVisible: modelCount > 0 && !searchField._editor.activeFocus
+        Binding on label {
+            target: searchField
+            //% "%n item(s) found"
+            value: qsTrId("sailfish-office-lb-%n-matches", modelCount)
+            when: modelCount > 0
+        }
+
+        onModelCountChanged: if (modelCount == 0) text = "" // Allow the placeholder
+        // to be visible for no results.
+        onIconizedChanged: if (!iconized) _editor.forceActiveFocus()
+
+        //: Placeholder text of SearchField
+        placeholderText: (modelCount == 0)
+            //% "No result"
+            ? qsTrId("sailfish-office-search-no-result")
+            //% "Search on document"
+            : qsTrId("sailfish-office-search-document")
+        onFocusChanged: {
+            if (focus) {
+                cursorPosition = text.length
+                searchField.iconized = false
+            }
+        }
+
+        inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase | Qt.ImhNoPredictiveText
+        EnterKey.iconSource: text != "" ? "image://theme/icon-m-enter-accept"
+                                        : "image://theme/icon-m-enter-close"
+        EnterKey.onClicked: {
+            focus = false
+            if (text != "") {
+                root.requestSearch(text)
+            } else {
+                iconized = true
+            }
+        }
+
+        background: null
+
+        Item {
+            parent: searchField // avoid TextBase contentItem auto-parenting
+            anchors.fill: parent
+
+            IconButton {
+                id: searchIcon
+                x: searchField.textLeftMargin - width - Theme.paddingSmall
+                width: icon.width
+                height: parent.height
+                icon.source: "image://theme/icon-m-search"
+                highlighted: down || root.down || searchField._editor.activeFocus
+
+                enabled: searchField.enabled
+
+                onClicked: {
+                    searchField.iconized = false
+                    searchField._editor.forceActiveFocus()
+                }
+            }
+
+            IconButton {
+                id: searchPrev
+                anchors {
+                    right: searchNext.left
+                    rightMargin: Theme.paddingLarge
+                }
+                width: icon.width
+                height: parent.height
+                icon.source: "image://theme/icon-m-left"
+
+                enabled: searchField.enabled
+                visible: !iconized && opacity > 0.
+
+                opacity: modelCount > 0 && !searchField._editor.activeFocus ? 1 : 0
+                Behavior on opacity { FadeAnimation {} }
+
+                onClicked: root.requestPreviousMatch()
+            }
+
+            IconButton {
+                id: searchNext
+                anchors {
+                    right: clearButton.left
+                    rightMargin: Theme.paddingLarge
+                }
+                width: icon.width
+                height: parent.height
+                icon.source: "image://theme/icon-m-right"
+
+                enabled: searchField.enabled
+                visible: !iconized && opacity > 0.
+
+                opacity: modelCount > 0 && !searchField._editor.activeFocus ? 1 : 0
+                Behavior on opacity { FadeAnimation {} }
+
+                onClicked: root.requestNextMatch()
+            }
+
+            IconButton {
+                id: clearButton
+                anchors {
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                }
+                width: icon.width
+                height: parent.height
+                icon.source: "image://theme/icon-m-clear"
+
+                enabled: searchField.enabled
+                visible: !iconized && opacity > 0.
+
+                opacity: searchField.width > 2 * Theme.itemSizeSmall ? 1. : 0.
+                Behavior on opacity { FadeAnimation {} }
+
+                onClicked: {
+                    // Cancel any pending search.
+                    root.requestCancel()
+                    if (!searchField._editor.activeFocus || searchField.text == "") {
+                        // Close case.
+                        searchField.iconized = true
+                        searchField.focus = false
+                    } else {
+                        // Clear case.
+                        searchField.text = ""
+                        searchField._editor.forceActiveFocus()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugin/ToolBar.qml
+++ b/plugin/ToolBar.qml
@@ -31,10 +31,14 @@ PanelBackground {
     property int _previousContentY
 
     onAutoShowHideChanged: {
-        if (autoShowHide && _active) {
-            autoHideTimer.start()
+        if (autoShowHide) {
+            if (_active) {
+                autoHideTimer.start()
+            }
         } else {
             autoHideTimer.stop()
+            // Keep a transiting toolbar visible.
+            _active = (offset > 0)
         }
     }
 


### PR DESCRIPTION
This pull request should match the new ui design for current capabilities of the toolbar, *i.e* page counter and search. The toolbar content is modified to contain BackgroundItem which width are the page width divided by the number of children in the toolbar. Like that, we can later easily add items for highlight and annotate.

* The first commit modifies the page counter to use this new design and also match the design mockups (replace « / » by « | » and don't use any icon).
* The second commit modifies the search tool by introducing a new Item called SearchBar that is a modified version of SearchField.qml (I kept the header for licences reasons) to add the two prev / next buttons and add an iconized state when in the tool bar. Also handle the number of matches with the label property (not shown in the mockups but present in the text).
* The third commit is a bug correction commit, to avoid the toolbar to continue hiding on action. For instance, when taping on the search icon while the bar is transitioning to hide, the search field was not displayed because the toolbar was finishing its transition regardless of autoShowHide becoming false.

Implementation is working on all orientations.