### PR TITLE
[office] Correct the ContextMenuHook not appearing at high zooming factors.

### DIFF
--- a/plugin/ContextMenuHook.qml
+++ b/plugin/ContextMenuHook.qml
@@ -69,7 +69,8 @@ Item {
         }
     }
 
-    width: parent.width
+    width: _menu && _menu._flickable ? _menu._flickable.width : 0
+    x:  _menu && _menu._flickable ? _menu._flickable.contentX : 0
     height: hookHeight + (_menu ? Theme.paddingSmall + _menu.height : 0.)
 
     Rectangle {


### PR DESCRIPTION
At high zooming factors, when tapping on a link to make the context menu appears, the area becomes black and there are some message in console about texture issues.

This is the old bitting texture limit issue. The width of the ContextMenuHook was too large. It was bind to its parent width, thus having the width of the full PDF.Canvas. When a ContextMenu is attached the effect to remove the diming is applied on the ContextMenu and its parent (here the ContextMenuHook). Thus the oversized texture.

The solution is to bind the width of the ContextMenuHook to the flickable width and shift its horizontal position by contentX. Like that the texture is always guaranteed to be smaller or equal to the screen.