### PR TITLE
Fix crash on password protected pdf files

### DIFF
--- a/pdf/pdfrenderthread.cpp
+++ b/pdf/pdfrenderthread.cpp
@@ -431,14 +431,14 @@ void PDFRenderThreadQueue::processPendingJob()
             }
     
             d->document = dj->m_document;
-            if (d->document && d->document->numPages() > 0) {
-                if (!d->document->isLocked()) {
-                    d->tocModel = new PDFTocModel(d->document);
-                    d->rescanDocumentLinks();
-                }
-            } else {
+
+            if (!d->document || (!d->document->isLocked() && d->document->numPages() == 0)) {
                 d->loadFailure = true;
+            } else if (!d->document->isLocked()) {
+                d->tocModel = new PDFTocModel(d->document);
+                d->rescanDocumentLinks();
             }
+
             job->deleteLater();
             emit d->q->loadFinished();
             break;

--- a/pdf/pdfselection.cpp
+++ b/pdf/pdfselection.cpp
@@ -28,6 +28,7 @@ public:
         , boxIndexStart(-1)
         , pageIndexStop(-1)
         , boxIndexStop(-1)
+        , handleReversed(false)
         , wiggle(4.)
     {
     }


### PR DESCRIPTION
Broken by 919030e00b51571, Poppler doesn't like numPages() asked from locked document.

Don't have pdf with 0 pages, so didn't test how that continues working. 

@dcaliste 