### PR TITLE
[office] Avoid warnings for unexpected null receiver. Fixes JB#36476

### DIFF
--- a/pdf/pdfcanvas.cpp
+++ b/pdf/pdfcanvas.cpp
@@ -127,8 +127,11 @@ PDFCanvas::~PDFCanvas()
 {
     for (int i = 0; i < d->pageCount; ++i) {
         PDFPage &page = d->pages[i];
-        page.texture->deleteLater();
-        page.texture = nullptr;
+
+        if (page.texture) {
+            page.texture->deleteLater();
+            page.texture = nullptr;
+        }
     }
 
     delete d->resizeTimer;


### PR DESCRIPTION
98dfd3a610c6 made use deleteLater without checking null pointer.

@dcaliste 