### PR TITLE
[office] Add a back button after an internal link has been taped.

### DIFF
--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -222,7 +222,8 @@ DocumentPage {
                                   || highlightButton.highlighted
                                   || view.selection.selected
             property Item activeItem
-            property real itemWidth: toolbar.width / children.length
+            property real itemWidth: Math.max(toolbar.width - pageCount.width, 0)
+                                     / (children.length - 1)
             height: parent.height
 
             function toggle(item) {
@@ -363,7 +364,9 @@ DocumentPage {
             }
             BackgroundItem {
                 id: pageCount
-                width: row.itemWidth
+                width: screen.sizeCategory <= Screen.Medium
+                       ? Math.max(toolbar.width / row.children.length, Screen.width / 4)
+                       : toolbar.width / row.children.length
                 height: parent.height
                 Label {
                     id: pageLabel

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -106,6 +106,7 @@ DocumentPage {
         anchors.fill: parent
         anchors.bottomMargin: toolbar.offset
         document: pdfDocument
+        onCanMoveBackChanged: if (canMoveBack) toolbar.show()
         onClicked: base.open = !base.open
         onLinkClicked: {
             base.open = false
@@ -216,14 +217,16 @@ DocumentPage {
         Row {
             id: row
             property bool active: pageCount.highlighted
+                                  || linkBack.visible
                                   || search.highlighted
                                   || !search.iconized
                                   || textButton.highlighted
                                   || highlightButton.highlighted
                                   || view.selection.selected
             property Item activeItem
+            property int nVisibleChildren: children.length - (linkBack.visible ? 0 : 1)
             property real itemWidth: Math.max(toolbar.width - pageCount.width, 0)
-                                     / (children.length - 1)
+                                     / (nVisibleChildren - 1)
             height: parent.height
 
             function toggle(item) {
@@ -363,10 +366,31 @@ DocumentPage {
                 }
             }
             BackgroundItem {
+                id: linkBack
+                width: row.itemWidth
+                height: parent.height
+                highlighted: pressed || backButton.pressed
+                opacity: view.canMoveBack ? 1. : 0.
+                visible: opacity > 0
+                Behavior on opacity { FadeAnimation{ duration: 400 } }
+                IconButton {
+                    id: backButton
+                    anchors.centerIn: parent
+                    highlighted: pressed || linkBack.pressed
+                    icon.source: "image://theme/icon-m-back"
+                    onClicked: linkBack.clicked(mouse)
+                }
+                onClicked: {
+                    row.toggle(linkBack)
+                    view.moveBack()
+                    toolbar.hide()
+                }
+            }
+            BackgroundItem {
                 id: pageCount
                 width: screen.sizeCategory <= Screen.Medium
-                       ? Math.max(toolbar.width / row.children.length, Screen.width / 4)
-                       : toolbar.width / row.children.length
+                       ? Math.max(toolbar.width / row.nVisibleChildren, Screen.width / 4)
+                       : toolbar.width / row.nVisibleChildren
                 height: parent.height
                 Label {
                     id: pageLabel


### PR DESCRIPTION
Add a back button in the toolbar when tapped on an internal goto link, see #89. Also add smooth scroll to the link location.

When tapping on an internal goto link, the view scrolls to the link target location and the toolbar is shown. The toolbar is kept visible, up to the moment the back button is either tapped, the view is scrolled more than the height of a screen, or the zoom changes. Going back to the previous location is also smoothly animated.