### PR TITLE
[office] Correct a blicking artefact happening on a link context menu after back button was pressed.

### DIFF
--- a/plugin/ContextMenuHook.qml
+++ b/plugin/ContextMenuHook.qml
@@ -23,13 +23,13 @@ Item {
     id: hook
 
     property bool active: _menu ? _menu.active : false
-    property int hookHeight
     property alias backgroundColor: background.color
     property alias backgroundOpacity: background.opacity
 
     property real _flickableContentHeight
     property bool _opened: _menu ? _menu._open : false
 
+    property int _hookHeight
     property var _menu
 
     // Used to emulate the MouseArea that trigger a ContextMenu
@@ -37,6 +37,11 @@ Item {
     property bool preventStealing
     signal positionChanged(point mouse)
     signal released(bool mouse)
+
+    function setTarget(targetY, targetHeight) {
+        y = targetY
+        _hookHeight = targetHeight
+    }
 
     function showMenu(menu) {
         _menu = menu
@@ -56,7 +61,10 @@ Item {
             // out of screen.
             _menu._flickable.contentY =
                 Math.max(_menu._flickableContentYAtOpen,
-                         hook.y + hookHeight + Theme.paddingSmall - _menu._flickable.height)
+                         hook.y + _hookHeight + Theme.paddingSmall - _menu._flickable.height)
+            // Reset menu flickable after menu is closed to avoid initialisation
+            // issues next time showMenu() is called.
+            _menu._flickable = null
         }
     }
     Connections {
@@ -71,7 +79,7 @@ Item {
 
     width: _menu && _menu._flickable ? _menu._flickable.width : 0
     x:  _menu && _menu._flickable ? _menu._flickable.contentX : 0
-    height: hookHeight + (_menu ? Theme.paddingSmall + _menu.height : 0.)
+    height: _hookHeight + (_menu ? Theme.paddingSmall + _menu.height : 0.)
 
     Rectangle {
         id: background

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -293,8 +293,7 @@ SilicaFlickable {
 
                 onClickedBoxChanged: {
                     if (clickedBox.width > 0) {
-                        contextHook.y = clickedBox.y
-                        contextHook.hookHeight = clickedBox.height
+                        contextHook.setTarget(clickedBox.y, clickedBox.height)
                     }
                 }
 
@@ -316,8 +315,7 @@ SilicaFlickable {
                 onClicked: base.clicked()
                 onAnnotationLongPress: base.annotationLongPress(annotation, contextHook)
                 onLongPress: {
-                    contextHook.y = pressAt.y
-                    contextHook.hookHeight = Theme.itemSizeSmall / 2
+                    contextHook.setTarget(pressAt.y, Theme.itemSizeSmall / 2)
                     base.longPress(pressAt, contextHook)
                 }
             }


### PR DESCRIPTION
I found a corner case when opening a context menu make the contentY change quickly to an offset position before returning to normal.

To reproduce:

* open a context menu on an external link (like one on the top right corner of the first page of the attached PDF) ;
* tap on a goto link (like the one on the page number, right bottom corner of the first page) ;
* tap on the back arrow and reopen the first context menu again.

The root of this is very hidden. It's the _flickableContentY property of the ContextMenu that triggers this. Following the previous steps:

* after opening the context menu the first time, the ContextMenu exists in memory and is attached to the ContextMenuHook that is taking the place of the link on the first page.
* when tapping on the goto link, the ContextMenuHook is moved to take the place of the box of the goto link.
* when tapping on the back arrow, and since the menu is closing and the height of the flickable is changing, the property of _flickableContentY is updated to ensure that the ContextMenuHook rectangle can be visible if contentY of the flickable is change accordingly.
* then, tapping on the link again, does not update _flickableContentY, because there is no reason (_flickableConentYAtOpen is the same), and when _open becomes true, the contentY is set to _flickableContentY which contains a not up-to-date value, thus the blinking.

Beside updating ContextMenu to ensure that _flickableConentYAtOpen is set to -1 or any non significant value, when hide() is called, I think it's safer to detach any menu from the ContextMenuHook when the hook is set to a different target. This is the purpose of this PR.
[examplePDF.pdf](https://github.com/sailfishos/sailfish-office/files/566585/Freemobile_0651353297_25-10-2016.pdf)
