### PR TITLE
[office] Fix pdf search string not fully visible on bigger font size.

### DIFF
--- a/plugin/SearchBarItem.qml
+++ b/plugin/SearchBarItem.qml
@@ -114,7 +114,9 @@ BackgroundItem {
 
         focusOutBehavior: FocusBehavior.ClearPageFocus
         font {
-            pixelSize: Theme.fontSizeLarge
+            // visible label doesn't leave much room. match count might go away if heavy full-document search is replaced
+            // with more incremental approach, so should be good for now
+            pixelSize: labelVisible ? Theme.fontSizeMediumBase : Theme.fontSizeLarge
             family: Theme.fontFamilyHeading
         }
 


### PR DESCRIPTION
A little hacky, but does its job.

@jpetrell 