### PR TITLE
[office] Use incremental search.

### DIFF
--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -89,8 +89,9 @@ public Q_SLOTS:
     void cancelPageRequest(int index);
     void requestPageSizes();
     void search(const QString &search, uint startPage = 0);
-    void cancelSearch();
-    void searchFinished(const QList<QPair<int, QRectF>> &matches);
+    void cancelSearch(bool resetModel = true);
+    void onSearchFinished();
+    void onSearchProgress(float fraction, const QList<QPair<int, QRectF>> &matches);
     void loadFinished();
     void jobFinished(PDFJob *job);
     void onPageModified(int page, const QRectF &subpart);

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -62,10 +62,11 @@ Q_SIGNALS:
     void loadFinished();
     void pageModified(int page, const QRectF &subpart);
     void jobFinished(PDFJob *job);
-    void searchFinished(const QList<QPair<int, QRectF>> &matches);
+    void searchFinished();
+    void searchProgress(float fraction, const QList<QPair<int, QRectF>> &newMatches);
 
 private Q_SLOTS:
-    void onSearchFinished();
+    void onSearchProgress(float fraction, uint beginIndex, uint nNewMatches);
     
 private:
     friend class PDFRenderThreadPrivate;

--- a/pdf/pdfsearchmodel.cpp
+++ b/pdf/pdfsearchmodel.cpp
@@ -23,18 +23,19 @@
 class PDFSearchModel::Private
 {
 public:
-    Private(const QList<QPair<int, QRectF> > &matches)
-      : m_matches(matches)
+    Private()
+      : m_fraction(0.f)
     {
         roles.insert(Page, "page");
         roles.insert(Rect, "rect");
     }
-    const QList<QPair<int, QRectF> > &m_matches;
+    QList<QPair<int, QRectF> > m_matches;
     QHash<int, QByteArray> roles;
+    float m_fraction;
 };
 
-PDFSearchModel::PDFSearchModel(const QList<QPair<int, QRectF> > &matches, QObject *parent)
-  : QAbstractListModel(parent), d(new Private(matches))
+PDFSearchModel::PDFSearchModel(QObject *parent)
+  : QAbstractListModel(parent), d(new Private)
 {
 }
 
@@ -81,4 +82,23 @@ int PDFSearchModel::rowCount(const QModelIndex& parent) const
 int PDFSearchModel::count() const
 {
     return d->m_matches.count();
+}
+
+float PDFSearchModel::fraction() const
+{
+    return d->m_fraction;
+}
+
+void PDFSearchModel::addMatches(float fraction, const QList<QPair<int, QRectF> > &matches)
+{
+    if (!matches.empty()) {
+        beginInsertRows(QModelIndex(), d->m_matches.count(),
+                        d->m_matches.count() + matches.count() - 1);
+        d->m_matches.append(matches);
+        endInsertRows();
+        emit countChanged();
+    }
+
+    d->m_fraction = fraction;
+    emit fractionChanged();
 }

--- a/pdf/pdfsearchmodel.h
+++ b/pdf/pdfsearchmodel.h
@@ -25,13 +25,14 @@ class PDFSearchModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(float fraction READ fraction NOTIFY fractionChanged)
 
 public:
     enum PDFSearchModelRoles {
         Page = Qt::UserRole + 1,
         Rect
     };
-    explicit PDFSearchModel(const QList<QPair<int, QRectF> > &matches, QObject *parent = 0);
+    explicit PDFSearchModel(QObject *parent = 0);
     virtual ~PDFSearchModel();
 
     virtual QVariant data(const QModelIndex &index, int role) const;
@@ -39,9 +40,12 @@ public:
     virtual QHash<int, QByteArray> roleNames() const;
 
     int count() const;
+    float fraction() const;
+    void addMatches(float fraction, const QList<QPair<int, QRectF> > &matches);
 
 Q_SIGNALS:
     void countChanged();
+    void fractionChanged();
 
 private:
     class Private;

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -245,12 +245,14 @@ DocumentPage {
                 iconizedWidth: row.itemWidth
                 height: parent.height
 
-                modelCount: pdfDocument.searchModel ? pdfDocument.searchModel.count : -1
+                searching: pdfDocument.searching
+                searchProgress: pdfDocument.searchModel ? pdfDocument.searchModel.fraction : 0.
+                matchCount: pdfDocument.searchModel ? pdfDocument.searchModel.count : -1
 
                 onRequestSearch: pdfDocument.search(text, view.currentPage - 1)
                 onRequestPreviousMatch: view.prevSearchMatch()
                 onRequestNextMatch: view.nextSearchMatch()
-                onRequestCancel: pdfDocument.cancelSearch()
+                onRequestCancel: pdfDocument.cancelSearch(!pdfDocument.searching)
                 onClicked: row.toggle(search)
             }
             BackgroundItem {

--- a/plugin/SearchBarItem.qml
+++ b/plugin/SearchBarItem.qml
@@ -43,8 +43,10 @@ BackgroundItem {
     id: root
 
     property bool iconized: true
-    property int modelCount: -1
+    property int matchCount: -1
     property real iconizedWidth
+    property bool searching
+    property alias searchProgress: progressBar.progress
 
     property real _margin: Math.max((iconizedWidth - searchIcon.width) / 2., 0.)
 
@@ -80,6 +82,25 @@ BackgroundItem {
         }
     }
     highlighted: down || searchIcon.down
+
+    Rectangle {
+        id: progressBar
+        property real progress: 0.0
+        height: parent.height
+        width: progress * parent.width
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: Theme.rgba(Theme.highlightBackgroundColor, 0.5) }
+            GradientStop { position: 1.0; color: Theme.rgba(Theme.highlightBackgroundColor, 0.0) }
+        }
+        opacity: searching ? 1. : 0.
+        visible: opacity > 0.
+
+        Behavior on width {
+            enabled: progressBar.visible
+            SmoothedAnimation { velocity: 480; duration: 200 }
+        }
+        Behavior on opacity { FadeAnimation {} }
+    }
 
     IconButton {
         id: searchIcon
@@ -125,11 +146,11 @@ BackgroundItem {
             + (searchNext.visible ? searchNext.width + Theme.paddingLarge : 0.)
         textTopMargin: labelVisible ? Theme.paddingSmall : (height/2 - _editor.implicitHeight/2)
 
-        labelVisible: root.modelCount > 0 && !searchField.activeFocus
+        labelVisible: root.matchCount > 0 && !searchField.activeFocus
         //% "%n item(s) found"
-        label: qsTrId("sailfish-office-lb-%n-matches", root.modelCount)
+        label: qsTrId("sailfish-office-lb-%n-matches", root.matchCount)
 
-        placeholderText: (root.modelCount == 0 && !activeFocus)
+        placeholderText: (root.matchCount == 0 && !activeFocus)
             //% "No result"
             ? qsTrId("sailfish-office-search-no-result")
             //% "Search on document"
@@ -137,21 +158,23 @@ BackgroundItem {
 
         Connections {
             target: root
-            onModelCountChanged: if (modelCount == 0) {
-                searchField.text = "" // Allow the placeholder
-                searchField._searchText = ""
+            onSearchingChanged: {
+                if (!searching && matchCount == 0) {
+                    searchField.text = "" // Allow the placeholder
+                }
             }
         }
+        on_SearchTextChanged: root.requestSearch(_searchText)
 
         onActiveFocusChanged: {
             if (activeFocus) {
+                text = _searchText
                 cursorPosition = text.length
             } else {
-                if (text != _searchText) {
-                    text = _searchText
-                }
                 if (!text) {
                     root.iconized = true
+                } else if (matchCount == 0 && !searching) {
+                    text = ""
                 }
             }
         }
@@ -162,9 +185,6 @@ BackgroundItem {
         EnterKey.onClicked: {
             if (text != "") {
                 _searchText = text
-                root.requestSearch(text)
-            } else {
-                root.iconized = true
             }
             focus = false
         }
@@ -194,7 +214,7 @@ BackgroundItem {
 
                 visible: opacity > 0.
 
-                opacity: root.modelCount > 0 && !searchField.activeFocus ? 1 : 0
+                opacity: root.matchCount > 0 && !searchField.activeFocus ? 1 : 0
                 Behavior on opacity { FadeAnimation {} }
 
                 onClicked: root.requestPreviousMatch()
@@ -212,7 +232,7 @@ BackgroundItem {
 
                 visible: opacity > 0.
 
-                opacity: root.modelCount > 0 && !searchField.activeFocus ? 1 : 0
+                opacity: root.matchCount > 0 && !searchField.activeFocus ? 1 : 0
                 Behavior on opacity { FadeAnimation {} }
 
                 onClicked: root.requestNextMatch()
@@ -227,8 +247,14 @@ BackgroundItem {
                 icon.source: "image://theme/icon-m-clear"
 
                 onClicked: {
+                    var _searching = root.searching
+
                     // Cancel any pending search.
                     root.requestCancel()
+
+                    // Cancel case, nothing to do further.
+                    if (_searching) return
+
                     searchField._searchText = ""
                     if (!searchField.activeFocus || searchField.text == "") {
                         // Close case.


### PR DESCRIPTION
Implement an incremental text search by signaling every 3 pages the additional matches since the last update. A singular modification is that now the search model advertised by the document is available since the beginning of the request with a zero count. A fraction of the job done is also signaled so one can implement a progress bar.

I had to change various things in the UI because some of the logic in SearchBarItem.qml was based on the assumption that the search model was given at the end of the search and that a count of zero was meaning no match. The clear / cancel button is now also a stop button that can stop the current search while keeping the results already found if pressed when searching.

I think, the biggest other change I made is that the search model is not anymore a reference on the search list owned by the thread but a copy that is slowly increased.