### PR TITLE
[office] Defer link scan on a page on request instead at load time.

### DIFF
--- a/pdf/pdfcanvas.h
+++ b/pdf/pdfcanvas.h
@@ -124,6 +124,7 @@ protected:
     virtual QSGNode* updatePaintNode(QSGNode *node, UpdatePaintNodeData*);
 
 private Q_SLOTS:
+    void linksFinished(int id, const QList<QPair<QRectF, QUrl> > &links);
     void pageModified(int id, const QRectF &subpart);
     void pageFinished(int id, int pageRenderWidth,
                       QRect subpart, QSGTexture *texture, int extraData);

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -51,7 +51,7 @@ public:
     ~PDFDocument();
 
 public:
-    typedef QMultiMap<int, QPair<QRectF, QUrl> > LinkMap;
+    typedef QList<QPair<QRectF, QUrl> > LinkList;
     typedef QList<QPair<QRectF, Poppler::TextBox*> > TextList;
 
     QString source() const;
@@ -61,7 +61,6 @@ public:
     bool searching() const;
     QObject* searchModel() const;
     
-    LinkMap linkTargets() const;
     TextList textBoxesAtPage(int page);
 
     bool isLoaded() const;
@@ -83,6 +82,7 @@ public Q_SLOTS:
     void setSource(const QString &source);
     void setAutoSavePath(const QString &filename);
     void requestUnLock(const QString &password);
+    void requestLinksAtPage(int page);
     void requestPage(int index, int size, QQuickWindow *window,
                      QRect subpart = QRect(), int extraData = 0);
     void prioritizeRequest(int index, int size, QRect subpart = QRect());
@@ -108,6 +108,7 @@ Q_SIGNALS:
     void documentFailedChanged();
     void documentLockedChanged();
     void documentModifiedChanged();
+    void linksFinished(int page, const LinkList &links);
     void pageFinished(int index, int resolution, QRect subpart,
                       QSGTexture *page, int extraData);
     void pageSizesFinished(const QList<QSizeF> &heights);

--- a/pdf/pdfjob.h
+++ b/pdf/pdfjob.h
@@ -36,6 +36,7 @@ public:
     enum JobType {
         LoadDocumentJob,
         UnLockDocumentJob,
+        LinksJob,
         RenderPageJob,
         PageSizesJob,
         SearchDocumentJob,
@@ -78,6 +79,18 @@ public:
 
 private:
     QString m_password;
+};
+
+class LinksJob : public PDFJob
+{
+    Q_OBJECT
+public:
+    LinksJob(int page);
+
+    virtual void run();
+
+    int m_page;
+    QList<QPair<QRectF, QUrl> > m_links;
 };
 
 class RenderPageJob : public PDFJob


### PR DESCRIPTION
Try to correct the long loading time of lengthy PDF files (like the PDF reference paper). This loading time is mainly due to the link scanning in all pages and in a smaller proportion to the construction of the table of content.

To remove the link loading time, I've made this done on demand for pages that are displayed and that has not yet retrieved the link rectangles. This works quite well IMHO, the initial loading time being well reduced. But currently there is one issue: the rendering jobs having the priority, the links appear on page after the pages themselves have been rendered.

Do you think this is an issue ? Should I find a way to better interlaced texture rendering and link scanning in the job queue ?