### PR TITLE
Jb35554

### DIFF
--- a/qml/FileListPage.qml
+++ b/qml/FileListPage.qml
@@ -135,14 +135,14 @@ Page {
 
         InfoLabel {
             parent: listView.contentItem
-            y: listView.headerItem.y + listView.headerItem.height + Theme.paddingLarge
+            y: listView.headerItem.y + pageHeader.height + searchField.height + (page.isPortrait ? Theme.itemSizeMedium : Theme.paddingLarge)
             //: View placeholder shown when there are no documents
             //% "No documents"
-            text: searchText.length == 0 ? qsTrId("sailfish-office-la-no_documents")
+            text: page.provider.count == 0 ? qsTrId("sailfish-office-la-no_documents")
                                          : //% "No documents found"
                                            qsTrId("sailfish-office-la-not-found")
             visible: opacity > 0
-            opacity: listView.count > 0 ? 0.0 : 1.0
+            opacity: (page.provider.ready && page.provider.count == 0) || (searchText.length > 0 && listView.count == 0) ? 1.0 : 0.0
             Behavior on opacity { FadeAnimation {} }
         }
 

--- a/qml/FileListPage.qml
+++ b/qml/FileListPage.qml
@@ -67,8 +67,16 @@ Page {
 
             parent: listView.headerItem
             width: parent.width
+            height: pageHeader.height + (searchEnabled ? searchField.height : 0)
+            Behavior on height {
+                NumberAnimation {
+                    duration: 150
+                    easing.type: Easing.InOutQuad
+                }
+            }
 
             PageHeader {
+                id: pageHeader
                 //: Application title
                 //% "Documents"
                 title: qsTrId("sailfish-office-he-apptitle")
@@ -91,18 +99,6 @@ Page {
                 EnterKey.onClicked: focus = false
 
                 Behavior on opacity { FadeAnimation { duration: 150 } }
-                Behavior on height {
-                    NumberAnimation {
-                        duration: 150
-                        easing.type: Easing.InOutQuad
-                    }
-                }
-                Binding {
-                    target: searchField
-                    when: !searchEnabled
-                    property: "height"
-                    value: 0
-                }
             }
         }
 


### PR DESCRIPTION
Documents app main page header no longer opens outside the view (caused by Binding element changing search field height to zero too late, after the content y had already been calculated).

Info label "No documents" no longer flickers on app launch even if user has documents. During search filtering "No documents found" label no longer incorrectly flickers to "No documents" during the hide transition. Info label vertical position no longer flickers during orientation change. Also moved the label a bit lower on portrait orientation where there is more space.