### PR TITLE
[office] Delegate table of content build to a dedicated thread.

### DIFF
--- a/pdf/pdfrenderthread.cpp
+++ b/pdf/pdfrenderthread.cpp
@@ -120,11 +120,11 @@ public:
 
     void run() {
         QThread::exec();
-        // Delete pending search that may use document.
+        // Delete pending search and toc that may use document.
         delete searchThread;
+        delete tocModel;
         autoSaveTo();
         delete document;
-        delete tocModel;
         deleteLater();
     }
 
@@ -276,6 +276,8 @@ int PDFRenderThread::pageCount() const
 QObject* PDFRenderThread::tocModel() const
 {
     QMutexLocker(&d->thread->mutex);
+    if (d->document && !d->document->isLocked() && !d->tocModel)
+        d->tocModel = new PDFTocModel(d->document);
     return d->tocModel;
 }
 
@@ -474,8 +476,6 @@ void PDFRenderThreadQueue::processPendingJob()
 
             if (!d->document || (!d->document->isLocked() && d->document->numPages() == 0)) {
                 d->loadFailure = true;
-            } else if (!d->document->isLocked()) {
-                d->tocModel = new PDFTocModel(d->document);
             }
 
             job->deleteLater();

--- a/pdf/pdftocmodel.h
+++ b/pdf/pdftocmodel.h
@@ -27,6 +27,7 @@ class PDFTocModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
 
 public:
     enum PDFTocModelRoles {
@@ -42,9 +43,16 @@ public:
     virtual QHash<int, QByteArray> roleNames() const;
 
     int count() const;
+    bool ready() const;
+
+    Q_INVOKABLE void requestToc();
 
 Q_SIGNALS:
     void countChanged();
+    void readyChanged();
+
+private Q_SLOTS:
+    void onTocAvailable();
 
 private:
     class Private;

--- a/plugin/PDFDocumentToCPage.qml
+++ b/plugin/PDFDocumentToCPage.qml
@@ -29,6 +29,8 @@ Page {
 
     allowedOrientations: Orientation.All
 
+    onTocModelChanged: tocModel.requestToc()
+
     SilicaListView {
         id: tocListView
 
@@ -42,14 +44,18 @@ Page {
 
         ViewPlaceholder {
             id: placeholder
+            enabled: tocListView.model
+                     && tocListView.model.ready
+                     && tocListView.model.count == 0
             //% "Document has no table of content"
             text: qsTrId("sailfish-office-me-no-toc")
         }
-        // The enabled attribute of the placeholder is not set by binding since
-        // the model object comes from a different thread and QML cannot listen
-        // on signals from a different thread. Thus, the attribute is set by
-        // reading the count value instead of a binding.
-        onModelChanged: placeholder.enabled = !model || (model.count == 0)
+        BusyIndicator {
+            anchors.centerIn: parent
+            size: BusyIndicatorSize.Large
+            z: 1
+            running: !tocListView.model || !tocListView.model.ready
+        }
 
         delegate: BackgroundItem {
             id: bg
@@ -71,7 +77,7 @@ Page {
                 id: pageNumberLabel
                 anchors {
                     right: parent.right
-                    rightMargin: Theme.paddingLarge
+                    rightMargin: Theme.horizontalPageMargin
                     verticalCenter: parent.verticalCenter
                 }
                 text: (model.pageNumber === undefined) ? "" : model.pageNumber


### PR DESCRIPTION
Second PR for PDF document load time improvement.

This time, the idea is to move the creation of the table of content model into a dedicated thread, to avoid doing it in the load thread.

The busy indicator and the associated ready property may look a bit overkill, because they almost never appear, but one can see them for the reference pdf document, by taping on the page count in the toolbar. Otherwise, I've never seen them appear…

As a result, the reference PDF document, now opens in the same duration as in Evince on desktop (almost).