### PR TITLE
[sailfish-office] Adapt to changed ShareMethodList behavior. Contributes to JB#35260

### DIFF
--- a/plugin/DocumentsSharingList.qml
+++ b/plugin/DocumentsSharingList.qml
@@ -37,6 +37,7 @@ ShareMethodList {
         filter: menuList.mimeType
     }
     source: menuList.path
+    popSharingPage: false
 
     header: PageHeader {
         title: menuList.title


### PR DESCRIPTION
Don't pop sharing page like normally done.