### PR TITLE
[office] Add a view placeholder for empty text files. JB#45282

### DIFF
--- a/models/trackerdocumentprovider.cpp
+++ b/models/trackerdocumentprovider.cpp
@@ -48,7 +48,7 @@ static const QString documentQuery{
     "?u nie:mimeType ?mimeType . "
     "?u tracker:available true . "
     "{ ?u a nfo:PaginatedTextDocument } "
-    "UNION { ?u a nfo:TextDocument . ?u nie:mimeType 'text/plain' } "
+    "UNION { ?u a nfo:TextDocument . ?u nie:mimeType 'text/plain' FILTER(fn:ends-with(nfo:fileName(?u),'.txt')) } "
     "UNION { ?u a nfo:Presentation } "
     "UNION { ?u a nfo:Spreadsheet } "
 "}"

--- a/plugin/PlainTextDocumentPage.qml
+++ b/plugin/PlainTextDocumentPage.qml
@@ -102,6 +102,16 @@ DocumentPage {
                 }
             }
 
+            ViewPlaceholder {
+                enabled: model.lineCount === 0
+                         && (model.status === PlainTextModel.Ready || model.status === PlainTextModel.Error)
+                text: model.status === PlainTextModel.Error
+                        //% "Error loading text file"
+                        ? qsTrId("sailfish-office-la-plain_text_error")
+                          //% "Empty text file"
+                        : qsTrId("sailfish-office-la-plain_text_empty")
+            }
+
             VerticalScrollDecorator {
                 color: Theme.highlightDimmerColor
                 anchors.rightMargin: horizontalFlickable.contentWidth - horizontalFlickable.width - horizontalFlickable.contentX

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -117,7 +117,6 @@ ApplicationWindow {
     function mimeToIcon(fileMimeType) {
         var iconType = "other"
         switch (fileMimeType) {
-        case "text/plain":
         case "text/x-vnote":
             iconType = "note"
             break
@@ -140,6 +139,7 @@ ApplicationWindow {
         case "application/vnd.openxmlformats-officedocument.presentationml.template":
             iconType = "presentation"
             break
+        case "text/plain":
         case "application/vnd.oasis.opendocument.text-master":
         case "application/vnd.oasis.opendocument.text":
         case "application/vnd.oasis.opendocument.text-template":


### PR DESCRIPTION
And change the icon, and restrict plain text files in the documents
list to those with a .txt extension.