### PR TITLE
[sailfish-office] Hide PDF toolbar when pull down menu is active.

### DIFF
--- a/plugin/ToolBar.qml
+++ b/plugin/ToolBar.qml
@@ -25,7 +25,7 @@ PanelBackground {
     property Item flickable
     property bool forceHidden
     property bool autoShowHide: true
-    property int offset: _active && !forceHidden ? height : 0
+    property int offset: _active && !forceHidden && !flickable.pullDownMenu.active ? height : 0
 
     property bool _active: true
     property int _previousContentY


### PR DESCRIPTION
When pulling down the flickable to get the pulley menu, this trigger the toolbar because we are moving "upward".

Disable this in the toolbar itself.