### PR TITLE
[sailfish-office] Correct note creation not working in PDF documents.  Fixes TJC#212151

### DIFF
--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -297,7 +297,7 @@ DocumentPage {
                     var pt = Qt.point(mouse.x, mouse.y)
                     doc.create(annotation,
                                function() {
-                                   var at = view.getPoitionAt(pt)
+                                   var at = view.getPositionAt(pt)
                                    annotation.attachAt(doc,
                                                        at[0], at[2], at[1])
                                })


### PR DESCRIPTION
Simple typo making note creation failing, see [TJC](https://together.jolla.com/question/212151/cant-create-notes-in-pdf/).