### PR TITLE
Various minor corrections in annotation handling

### DIFF
--- a/plugin/ContextMenuHook.qml
+++ b/plugin/ContextMenuHook.qml
@@ -27,6 +27,7 @@ Item {
     property alias backgroundOpacity: background.opacity
 
     property real _flickableContentHeight
+    property real _flickableContentYAtOpen
     property bool _opened: _menu ? _menu._open : false
 
     property int _hookHeight
@@ -45,7 +46,7 @@ Item {
 
     function showMenu(menu) {
         _menu = menu
-        menu.show(hook)
+        menu.open(hook)
         _flickableContentHeight = _menu._flickable.contentHeight
     }
 
@@ -60,11 +61,13 @@ Item {
             // if the device has been rotated and the link would be sent
             // out of screen.
             _menu._flickable.contentY =
-                Math.max(_menu._flickableContentYAtOpen,
+                Math.max(_flickableContentYAtOpen,
                          hook.y + _hookHeight + Theme.paddingSmall - _menu._flickable.height)
             // Reset menu flickable after menu is closed to avoid initialisation
             // issues next time showMenu() is called.
             _menu._flickable = null
+        } else {
+            _flickableContentYAtOpen = _menu._flickable.contentY
         }
     }
     Connections {
@@ -72,7 +75,7 @@ Item {
         onContentHeightChanged: {
             // Update the initial opening position with the zoom factor
             // if the contentHeight is changed while menu was displayed.
-            _menu._flickableContentYAtOpen *= _menu._flickable.contentHeight / _flickableContentHeight
+            _flickableContentYAtOpen *= _menu._flickable.contentHeight / _flickableContentHeight
             _flickableContentHeight = _menu._flickable.contentHeight
         }
     }

--- a/plugin/PDFContextMenuHighlight.qml
+++ b/plugin/PDFContextMenuHighlight.qml
@@ -119,9 +119,9 @@ ContextMenu {
               : qsTrId("sailfish-office-me-pdf-hl-anno-comment-edit")
         onClicked: {
             if (contextMenuHighlight.annotation.contents == "") {
-                pdfDocument.create(contextMenuHighlight.annotation)
+                doc.create(contextMenuHighlight.annotation)
             } else {
-                pdfDocument.edit(contextMenuHighlight.annotation)
+                doc.edit(contextMenuHighlight.annotation)
             }
         }
     }

--- a/plugin/PDFContextMenuText.qml
+++ b/plugin/PDFContextMenuText.qml
@@ -32,10 +32,10 @@ ContextMenu {
         onClicked: {
             var annotation = textComponent.createObject(contextMenuText)
             annotation.color = "#202020"
-            pdfDocument.create(annotation,
+            doc.create(annotation,
                                function() {
                                    var at = view.getPositionAt(contextMenuText.at)
-                                   annotation.attachAt(pdfDocument, at[0], at[2], at[1])
+                                   annotation.attachAt(doc, at[0], at[2], at[1])
                                })
         }
         Component {
@@ -47,7 +47,7 @@ ContextMenu {
         visible: contextMenuText.annotation
         //% "Edit"
         text: qsTrId("sailfish-office-me-pdf-txt-anno-edit")
-        onClicked: pdfDocument.edit(contextMenuText.annotation)
+        onClicked: doc.edit(contextMenuText.annotation)
     }
     MenuItem {
         visible: contextMenuText.annotation

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -426,8 +426,8 @@ DocumentPage {
                                              {"annotation": annotation})
             obj.pageCompleted.connect(function(edit) {
                 edit.remove.connect(function() {
-                    pageStack.pop()
                     annotation.remove()
+                    pageStack.pop()
                 })
             })
         }

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -294,7 +294,7 @@ DocumentPage {
                 anchors.fill: parent
                 onClicked: {
                     var annotation = textComponent.createObject(textTool)
-                    var pt = Qt.point(mouse.x, mouse.y)
+                    var pt = Qt.point(view.contentX + mouse.x, view.contentY + mouse.y)
                     doc.create(annotation,
                                function() {
                                    var at = view.getPositionAt(pt)


### PR DESCRIPTION
It's a follow-up of #135 after comment from poster on TJC mentioning that notes where not created at the right place.

Testing this, I've found several minor issue with annotation handling after migration to latest design:
* dismissing a long press context menu was making the flickable scroll to top.
* creation and modification of a note from the context menu was doing nothing because of a wrong id in PDFContextMenu*.qml.
* notes created from toolbar were not positioned properly because the 'at' argument was missing the content offsets that existed before.

Quick tests of annotation creation and modification in a zoomed-in document were not showing additional bugs. Maybe @pvuorela or @jpetrell if you have time to test also, you may find something else. Tell me, I'll try to give a look. Notice, annotation deletion is currently segfaulting… I still need to investigate this further.