### PR TITLE
Correct search bar progress not filling-up toolbar height. Contributes TJC#212568

### DIFF
--- a/plugin/IndexButton.qml
+++ b/plugin/IndexButton.qml
@@ -29,7 +29,7 @@ MouseArea {
     enabled: count > 1 && allowed
     opacity: count > 0 && allowed ? (count > 1 ? 1.0 : Theme.opacityHigh) : 0.0
     width: Theme.itemSizeSmall
-    height: Theme.itemSizeSmall
+    height: parent.height
 
     Label {
         anchors.centerIn: parent

--- a/plugin/IndexButton.qml
+++ b/plugin/IndexButton.qml
@@ -20,6 +20,7 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 MouseArea {
+    id: root
     property bool allowed: true
     property color color: Theme.primaryColor
     property int index
@@ -35,7 +36,7 @@ MouseArea {
         anchors.centerIn: parent
         width: Math.min(parent.width - Theme.paddingSmall, implicitWidth)
         fontSizeMode: Text.HorizontalFit
-        color: highlighted ? Theme.highlightColor : parent.color
+        color: root.highlighted ? Theme.highlightColor : parent.color
         text: index + " | " + count
     }
 }

--- a/plugin/SearchBarItem.qml
+++ b/plugin/SearchBarItem.qml
@@ -39,7 +39,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 
-BackgroundItem {
+Item {
     id: root
 
     property bool active
@@ -47,15 +47,16 @@ BackgroundItem {
     property real expandedWidth
     property bool searching
     property alias searchProgress: progressBar.progress
+    property alias highlighted: searchIcon.highlighted
 
     property real _margin: Math.max((width - searchIcon.width) / 2., 0.)
 
+    signal clicked()
     signal requestSearch(string text)
     signal requestPreviousMatch()
     signal requestNextMatch()
     signal requestCancel()
 
-    onClicked: active = true
     onActiveChanged: if (active) searchField.forceActiveFocus()
 
     states: State {
@@ -74,7 +75,6 @@ BackgroundItem {
             duration: 400
         }
     }
-    highlighted: down || searchIcon.down
 
     Rectangle {
         id: progressBar
@@ -104,11 +104,11 @@ BackgroundItem {
         width: icon.width
         height: parent.height
         icon.source: "image://theme/icon-m-search"
-        highlighted: down || root.down || searchField.activeFocus
+        highlighted: down || searchField.activeFocus
 
         onClicked: {
-            root.clicked(mouse)
-            searchField.forceActiveFocus()
+            root.active = true
+            root.clicked()
         }
     }
 

--- a/plugin/ToolBar.qml
+++ b/plugin/ToolBar.qml
@@ -75,8 +75,8 @@ PanelBackground {
         id: contentItem
 
         spacing: Theme.paddingLarge
-        anchors.verticalCenter: parent.verticalCenter
         x: Math.max(0, parent.width/2 - width/2)
+        height: parent.height
     }
 
     Connections {


### PR DESCRIPTION
As [reported by @rozgwi on TJC](https://together.jolla.com/question/212568/documents-misaligned-toolbar-on-xperia-x/), the search progress bar was not filling properly up the toolbar height. I'm also pushing an additional commit to correct the page indicator not highlighted on press.

@pvuorela and @jpetrell, during the redesigned, you choose to remove BackgroundItem from toolbar items. I guess it's by design to use only IconButton there. I've one question though: the search icon is still a BackgroundItem and when pressed, it is highlighted with a solid coloured rectangle, while all other icon buttons are not. Should we correct this inconsistency by making SearchBarItem to inherit IconButton instead of BackgroundItem ? Or should we add BackgroundItem to all other IconButtons ?