### PR TITLE
[sailfish-office] Increase the size of the page index in toolbar. Contributes to TJC#212568

### DIFF
--- a/plugin/IndexButton.qml
+++ b/plugin/IndexButton.qml
@@ -29,12 +29,13 @@ MouseArea {
 
     enabled: count > 1 && allowed
     opacity: count > 0 && allowed ? (count > 1 ? 1.0 : Theme.opacityHigh) : 0.0
-    width: Theme.itemSizeSmall
+    width: Math.min(Theme.itemSizeMedium, label.implicitWidth + Theme.paddingSmall)
     height: parent.height
 
     Label {
+        id: label
         anchors.centerIn: parent
-        width: Math.min(parent.width - Theme.paddingSmall, implicitWidth)
+        width: parent.width - Theme.paddingSmall
         fontSizeMode: Text.HorizontalFit
         color: root.highlighted ? Theme.highlightColor : parent.color
         text: index + " | " + count

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -375,6 +375,7 @@ DocumentPage {
 
         IconButton {
             id: linkBack
+            anchors.verticalCenter: parent.verticalCenter
             opacity: view.canMoveBack ? 1. : 0.
             visible: opacity > 0
             Behavior on opacity { FadeAnimator { duration: 400 } }


### PR DESCRIPTION
Following discussion in [TJC thread](https://together.jolla.com/question/212568/documents-misaligned-toolbar-on-xperia-x/), I propose to expand a bit the size of the page index in PDF toolbar. For documents with many pages (like more than 100), the current label is shrinking to fit into a itemSizeSmall width.

I propose to expand this to itemSizeMedium, and to avoid to have wider space for documents with few pages (< 10), I'm changing a bit the width calculation logic to (label.implicitWidth + padding) limited by itemSizeMedium.