### PR TITLE
[sailfish-office] Don't use annotation boundary after removal.

### DIFF
--- a/pdf/pdfrenderthread.cpp
+++ b/pdf/pdfrenderthread.cpp
@@ -353,10 +353,11 @@ void PDFRenderThread::removeAnnotation(Poppler::Annotation *annotation, int page
         return;
     if (d->annotations.contains(pageIndex))
         d->annotations[pageIndex].removeOne(annotation);
+    QRectF boundary(annotation->boundary());
     Poppler::Page *page = d->document->page(pageIndex);
     page->removeAnnotation(annotation);
     delete page;
-    emit pageModified(pageIndex, annotation->boundary());
+    emit pageModified(pageIndex, boundary);
 }
 
 void PDFRenderThread::setAutoSaveName(const QString &filename)


### PR DESCRIPTION
@pvuorela, sorry I was mistaken with ec21e4eba266f0ad23417970bf2b39c0f4f4211d. It's not fixing the crash issue, I think I was mislead by the fact that it was working in ```gdb``` where I tested. Anyway, the (hopefully) real fix is coming with this PR. Maybe an upgrade in Poppler make that removed annotation are deleted soon than before and we cannot the pointer anymore afterwards. So, I'm saving the bounding box for the signal before removing the annotation.