### PR TITLE
Ensure zooming is always possible, even on a large screen

### DIFF
--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) 2013-2014 Jolla Ltd.
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
  * Contact: Robin Burchell <robin.burchell@jolla.com>
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin/SpreadsheetPage.qml
+++ b/plugin/SpreadsheetPage.qml
@@ -86,7 +86,7 @@ DocumentPage {
             view: documentView
             flickable: flickable
             useZoomProxy: false
-            maximumZoom: 10.0
+            maximumZoom: Math.max(10.0, 2.0 * minimumZoom)
             minimumZoomFitsWidth: true
         }
 

--- a/plugin/SpreadsheetPage.qml
+++ b/plugin/SpreadsheetPage.qml
@@ -1,5 +1,7 @@
 /*
- * Copyright (C) 2013-2014 Jolla Ltd.
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2019 Open Mobile Platform LLC.
+ *
  * Contact: Robin Burchell <robin.burchell@jolla.com>
  *
  * This program is free software; you can redistribute it and/or

--- a/plugin/TextDocumentPage.qml
+++ b/plugin/TextDocumentPage.qml
@@ -75,7 +75,7 @@ DocumentPage {
             id: viewController
             view: documentView
             flickable: flickable
-            maximumZoom: 5.0
+            maximumZoom: Math.max(5.0, 2.0 * minimumZoom)
             minimumZoomFitsWidth: true
         }
 


### PR DESCRIPTION
The maximum zoom level was previously set to 10. On a large screen, a
small file could have a minimum zoom level larger than this. As a
result, the bounds check (min <= zoom <= max) in Calligra's
ViewController::zoom() method always failed, and the zoom became locked
to some initial value.

The overlay tool icons for Spreadsheets are shown only when the document
is at minimum zoom level. Since the minimum zoom level was never
reached, as a side effect the tool icons would never appear.

This change ensures that the maximum zoom level is always larger than
the minimum zoom level, ensuring that zooming is always possible and
that the tools can be made visible.