### PR TITLE
[sailfish-office] Use left aligned details page items. Fixes JB#41622

### DIFF
--- a/plugin/DetailsPage.qml
+++ b/plugin/DetailsPage.qml
@@ -49,10 +49,11 @@ Page {
             }
 
             DetailItem {
-                //: File name detail of the document
-                //% "File Name"
-                label: qsTrId("sailfish-office-la-filename")
-                value: info.fileName
+                //: File path detail of the document
+                //% "File path"
+                label: qsTrId("sailfish-office-la-filepath")
+                value: info.filePath
+                alignment: Qt.AlignLeft
             }
 
             DetailItem {
@@ -60,6 +61,7 @@ Page {
                 //% "Size"
                 label: qsTrId("sailfish-office-la-filesize")
                 value: Format.formatFileSize(info.fileSize)
+                alignment: Qt.AlignLeft
             }
 
             DetailItem {
@@ -67,18 +69,20 @@ Page {
                 //% "Type"
                 label: qsTrId("sailfish-office-la-filetype")
                 value: info.mimeTypeComment
+                alignment: Qt.AlignLeft
             }
 
             DetailItem {
                 //: Last modified date of the document
-                //% "Last Modified"
+                //% "Last modified"
                 label: qsTrId("sailfish-office-la-lastmodified")
                 value: Format.formatDate(info.modifiedDate, Format.DateFull)
+                alignment: Qt.AlignLeft
             }
 
             DetailItem {
                 label: {
-                    switch(page.mimeType) {
+                    switch (page.mimeType) {
                         case "application/vnd.oasis.opendocument.spreadsheet":
                         case "application/x-kspread":
                         case "application/vnd.ms-excel":
@@ -120,6 +124,7 @@ Page {
                     }
                 }
                 value: page.indexCount
+                alignment: Qt.AlignLeft
             }
         }
 

--- a/plugin/fileinfo.cpp
+++ b/plugin/fileinfo.cpp
@@ -70,9 +70,14 @@ QString FileInfo::fileName() const
     return d->fileInfo.fileName();
 }
 
-QUrl FileInfo::fullPath() const
+QUrl FileInfo::fileUrl() const
 {
     return d->path;
+}
+
+QString FileInfo::filePath() const
+{
+    return d->fileInfo.filePath();
 }
 
 qint64 FileInfo::fileSize() const

--- a/plugin/fileinfo.h
+++ b/plugin/fileinfo.h
@@ -28,7 +28,8 @@ class FileInfo : public QObject
     Q_OBJECT
     Q_PROPERTY(QString source READ source WRITE setSource NOTIFY sourceChanged)
     Q_PROPERTY(QString fileName READ fileName NOTIFY sourceChanged)
-    Q_PROPERTY(QUrl fullPath READ fullPath NOTIFY sourceChanged)
+    Q_PROPERTY(QUrl fileUrl READ fileUrl NOTIFY sourceChanged)
+    Q_PROPERTY(QString filePath READ filePath NOTIFY sourceChanged)
     Q_PROPERTY(qint64 fileSize READ fileSize NOTIFY sourceChanged)
     Q_PROPERTY(QString mimeType READ mimeType NOTIFY sourceChanged)
     Q_PROPERTY(QString mimeTypeComment READ mimeTypeComment NOTIFY sourceChanged)
@@ -40,7 +41,8 @@ public:
 
     QString source() const;
     QString fileName() const;
-    QUrl fullPath() const;
+    QUrl fileUrl() const;
+    QString filePath() const;
     qint64 fileSize() const;
     QString mimeType() const;
     QString mimeTypeComment() const;

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -55,6 +55,7 @@ ApplicationWindow {
         id: fileInfo
     }
 
+    // file = file or url
     function openFile(file) {
         fileInfo.source = file
 
@@ -102,12 +103,12 @@ ApplicationWindow {
             break
 
         default:
-            console.log("Warning: Unrecognised file type for file " + fileInfo.fullPath)
+            console.log("Warning: Unrecognised file type for file " + fileInfo.filePath)
         }
 
         if (handler != "") {
             pageStack.push(handler,
-                           { title: fileInfo.fileName, source: fileInfo.fullPath, mimeType: fileInfo.mimeType },
+                           { title: fileInfo.fileName, source: fileInfo.fileUrl, mimeType: fileInfo.mimeType },
                            PageStackAction.Immediate)
         }
 

--- a/rpm/sailfish-office.spec
+++ b/rpm/sailfish-office.spec
@@ -18,7 +18,7 @@ BuildRequires: qt5-qttools-linguist
 BuildRequires: pkgconfig(icu-i18n)
 Requires: calligra-components >= 2.7.9+git4
 Requires: calligra-filters >= 2.7.9+git4
-Requires: sailfishsilica-qt5 >= 1.1.53
+Requires: sailfishsilica-qt5 >= 1.1.63
 Requires: sailfish-components-accounts-qt5
 Requires: sailfish-components-textlinking
 Requires: libqt5sparql-tracker


### PR DESCRIPTION
Also now using full file path as there is more space for it.

FileInfo adjusted a little not to confuse paths and urls.

@jpetrell @saukko 