### PR TITLE
[sailfish-office] Fix crash when adding pdf annotation below the document. Fixes JB#48393

### DIFF
--- a/pdf/pdfdocument.cpp
+++ b/pdf/pdfdocument.cpp
@@ -174,7 +174,11 @@ void PDFDocument::setAutoSavePath(const QString &filename)
 void PDFDocument::addAnnotation(Poppler::Annotation *annotation, int pageIndex,
                                 bool normalizeSize)
 {
-    d->thread->addAnnotation(annotation, pageIndex, normalizeSize);
+    if (pageIndex < 0) {
+        qWarning() << "Invalid page index for annotation";
+    } else {
+        d->thread->addAnnotation(annotation, pageIndex, normalizeSize);
+    }
 }
 
 QList<Poppler::Annotation*> PDFDocument::annotations(int page) const


### PR DESCRIPTION
On a very short document it's possible to try adding an annotation
below the document area. Doing that made the app crash.

Now the operation fails silently on the UI side, but should be quite much
better already.

@dcaliste @jpetrell 