### PR TITLE
Ensure new page layouts re-use existing textures when zooming

### DIFF
--- a/pdf/pdfcanvas.cpp
+++ b/pdf/pdfcanvas.cpp
@@ -321,6 +321,7 @@ void PDFCanvas::layout()
             page.renderWidth = d->pages.value(i).renderWidth;
             page.textureArea = d->pages.value(i).textureArea;
             page.image = d->pages.value(i).image;
+            page.hasImage = d->pages.value(i).hasImage;
             page.patches = d->pages.value(i).patches;
             page.links = d->pages.value(i).links;
         }


### PR DESCRIPTION
When the layout of a page changes a new PDFPage instance is created, and
the details (including the texture) attached to any existing instance of
the same page are copied over to the new instance. The hasImage flag was
being omitted from the copy, causing the renderer to think there was no
image to use, even when there was. As a result, when zooming into or out
of a page, the existing image (in the wrong resolution, but still
usable) was being lost while the new version was being redrawn.

This change makes it so that the old image is used in a scaled form,
making zooming appear more responsive.

This was a regression introduced in commit
b2c78650cba4688d80533aafda501e68a332c83a