### PR TITLE
[office] Fix pdf annotation boundary. Fixes JB#48952

### DIFF
--- a/pdf/pdfannotation.cpp
+++ b/pdf/pdfannotation.cpp
@@ -97,7 +97,7 @@ void PDFAnnotation::attach(PDFDocument *document, PDFSelection *selection)
     
     QRectF bounds = word.second;
     for (int i = 1; i < selection->count(); i++)
-        bounds.united(selection->rectAt(i).second);
+        bounds |= selection->rectAt(i).second;
 
     d->m_annotation->setBoundary(bounds);
     d->m_document->addAnnotation(d->m_annotation, d->m_page);


### PR DESCRIPTION
QRectF::united() is const and the code didn't seem to do much.

@dcaliste @llewelld @jpetrell 