### PR TITLE
[office] Hide the application background in the homescreen when viewing document pages. Contributes to JB#49705

### DIFF
--- a/plugin/CalligraDocumentPage.qml
+++ b/plugin/CalligraDocumentPage.qml
@@ -26,7 +26,6 @@ DocumentPage {
 
     property alias document: doc
     property alias contents: contentsModel
-    property alias backgroundColor: background.color
     property int coverAlignment: Qt.AlignLeft | Qt.AlignTop
     property int coverFillMode: Image.PreserveAspectCrop
 
@@ -34,17 +33,6 @@ DocumentPage {
         // This is a function which can be shadowed because the currentIndex property doesn't
         // notify reliably and nothing needs to bind to it.
         return doc.currentIndex
-    }
-
-    _opaqueBackground: background.color !== "transparent"
-
-    Rectangle {
-        id: background
-        color: "transparent"
-        z: -1
-        anchors.fill: parent
-        parent: page._backgroundParent
-        visible: page._opaqueBackground
     }
 
     backNavigation: !busy // During loading the UI is unresponsive, don't show page indicator as back-stepping is not possible

--- a/rpm/sailfish-office.spec
+++ b/rpm/sailfish-office.spec
@@ -18,7 +18,7 @@ BuildRequires: qt5-qttools-linguist
 BuildRequires: pkgconfig(icu-i18n)
 Requires: calligra-components
 Requires: calligra-filters >= 3.1.0+git18
-Requires: sailfishsilica-qt5 >= 1.1.82
+Requires: sailfishsilica-qt5 >= 1.1.107
 Requires: sailfish-components-accounts-qt5
 Requires: sailfish-components-textlinking
 Requires: libqt5sparql-tracker


### PR DESCRIPTION
Use the Page backgroundColor property which is capable of a few more
optimisations instead of the background rectangle in pages.