### PR TITLE
[sailfish-office] Add sharing to permissions.

### DIFF
--- a/sailfish-office.desktop
+++ b/sailfish-office.desktop
@@ -11,6 +11,6 @@ X-Maemo-Object-Path=/org/sailfishos/office/ui
 X-Maemo-Method=org.sailfishos.Office.ui.activateWindow
 
 [X-Sailjail]
-Permissions=Documents;Downloads;MediaIndexing
+Permissions=Documents;Downloads;MediaIndexing;Sharing
 ApplicationName=Office
 OrganizationName=org.sailfishos


### PR DESCRIPTION
@pvuorela currently, if you open a sharing page inside the application, nothing happens.