### PR TITLE
[sailfish-office] Add notifications permission.

### DIFF
--- a/sailfish-office.desktop
+++ b/sailfish-office.desktop
@@ -11,6 +11,6 @@ X-Maemo-Object-Path=/org/sailfishos/office/ui
 X-Maemo-Method=org.sailfishos.Office.ui.activateWindow
 
 [X-Sailjail]
-Permissions=Documents;Downloads;MediaIndexing;Sharing
+Permissions=Documents;Downloads;MediaIndexing;Sharing;Notifications
 ApplicationName=Office
 OrganizationName=org.sailfishos


### PR DESCRIPTION
Notifications are used as information bubble to provide
feedback when adding annotations in PDF files.

Open a PDF and in the toolbar tap on the pen for instance. Doing it should open a minor notification saying that you can highlight text with the finger.

@rainemak and @pvuorela, sorry to be slow ;)