### PR TITLE
[sailfish-office] Update application and organisation name. Fixes JB#52708

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -96,8 +96,8 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     auto app = createApplication(argc, argv);
     // Note, these must be said now, otherwise some plugins using QSettings
     // will get terribly confused when they fail to load properly.
-    app->setOrganizationName("Sailfish");
-    app->setApplicationName("Sailfish Office");
+    app->setOrganizationName("org.sailfishos");
+    app->setApplicationName("Office");
 
     auto view = createView("Main.qml");
 


### PR DESCRIPTION
As discussed from sailfishos/sailjail-permissions#33, I'm changing application name and organisation name for the sailfish-office executable also, so that QML storage can be accessible via sailjail automatically.

I'm not proposing to migrate old database because it's just view settings per document. Not a big deal to loose them during transition.

@Tomin1 and @pvuorela what's your opinion ?