### PR TITLE
Migrate to Tracker3 

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -2,8 +2,6 @@
 #define CONFIG_H
 
 #define QML_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/sailfish-office/"
-#define IMAGES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/sailfish-office/images/"
 #define TRANSLATION_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/translations/"
-#define CALLIGRA_QML_PLUGIN_DIR "${CALLIGRA_QML_PLUGIN_DIR}"
 
 #endif //CONFIG_H

--- a/main.cpp
+++ b/main.cpp
@@ -68,7 +68,6 @@ QSharedPointer<QQuickView> createView(const QString &file)
     qmlRegisterInterface<DocumentProvider>("DocumentProvider");
 
     QSharedPointer<QQuickView> view(MDeclarativeCache::qQuickView());
-    view->engine()->addImportPath(CALLIGRA_QML_PLUGIN_DIR);
     view->setSource(QUrl::fromLocalFile(QML_INSTALL_DIR + file));
 
     new DBusAdaptor(view.data());

--- a/models/trackerdocumentprovider.h
+++ b/models/trackerdocumentprovider.h
@@ -54,7 +54,7 @@ public Q_SLOTS:
 
 private Q_SLOTS:
     void searchFinished();
-    void trackerGraphChanged(const QString &className, const QVariantList&, const QVariantList&);
+    void trackerGraphChanged(const QString &graphName);
 
 private:
     class Private;

--- a/plugin/sailfishofficeplugin.cpp
+++ b/plugin/sailfishofficeplugin.cpp
@@ -57,8 +57,6 @@ void SailfishOfficePlugin::initializeEngine(QQmlEngine *engine, const char *uri)
 {
     Q_ASSERT(uri == QLatin1String("Sailfish.Office"));
 
-    engine->addImportPath(CALLIGRA_QML_PLUGIN_DIR);
-
     Translator *engineeringEnglish = new Translator(engine);
     engineeringEnglish->load("sailfish-office_eng_en", TRANSLATION_INSTALL_DIR);
 

--- a/rpm/sailfish-office.spec
+++ b/rpm/sailfish-office.spec
@@ -20,7 +20,7 @@ Requires: calligra-filters >= 3.1.0+git18
 Requires: sailfishsilica-qt5 >= 1.1.107
 Requires: sailfish-components-accounts-qt5
 Requires: sailfish-components-textlinking
-Requires: libqt5sparql-tracker
+Requires: libqt5sparql-tracker-direct
 Requires: sailjail-launch-approval
 #Requires: qt5-qtqml-import-webkitplugin
 Requires: nemo-qml-plugin-configuration-qt5


### PR DESCRIPTION
Switched to libtracker-sparql based driver and implemented a simple graph update api: https://git.sailfishos.org/mer-core/libqtsparql/merge_requests/10

One potentially problematic detail now is that the metadata extraction with Tracker3 seems to start only when needed, i.e. the Documents app launched the first time. At the moment this doesn't recognize the ongoing mining and will say for some time there are no documents on the device. Not sure at the moment what to do with that, but think I'll first adapt the remaining parts to the new tracker, and perhaps could first merge this sort of version anyway.

@llewelld @rainemak @okodron @abranson 