### PR TITLE
[office] Add UserDirs permission. JB#54876 OMP#JOLLA-239

### DIFF
--- a/sailfish-office.desktop
+++ b/sailfish-office.desktop
@@ -12,6 +12,6 @@ X-Maemo-Object-Path=/org/sailfishos/office/ui
 X-Maemo-Method=org.sailfishos.Office.ui.openFile
 
 [X-Sailjail]
-Permissions=Documents;Downloads;MediaIndexing;Sharing;RemovableMedia
+Permissions=UserDirs;MediaIndexing;Sharing;RemovableMedia
 ApplicationName=Office
 OrganizationName=org.sailfishos


### PR DESCRIPTION
Add UserDirs permission to allow sharing from any of those directories.
As Documents and Downloads are part of UserDirs, they are not needed
separately.