### PR TITLE
[sailfish-office] Remove unneeded Sharing permission. JB#55380

### DIFF
--- a/sailfish-office.desktop
+++ b/sailfish-office.desktop
@@ -12,6 +12,6 @@ X-Maemo-Object-Path=/org/sailfishos/office/ui
 X-Maemo-Method=org.sailfishos.Office.ui.openFile
 
 [X-Sailjail]
-Permissions=UserDirs;MediaIndexing;Sharing;RemovableMedia
+Permissions=UserDirs;MediaIndexing;RemovableMedia
 ApplicationName=Office
 OrganizationName=org.sailfishos


### PR DESCRIPTION
Sharing is allowed by default, separate permission is not needed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>