### PR TITLE
Fix tap handling on pdf password field. Fixes JB#58742

### DIFF
--- a/plugin/PDFContextMenuHighlight.qml
+++ b/plugin/PDFContextMenuHighlight.qml
@@ -22,6 +22,7 @@ import Sailfish.Office.PDF 1.0
 
 ContextMenu {
     id: contextMenuHighlight
+
     property Annotation annotation
 
     InfoLabel {
@@ -61,7 +62,7 @@ ContextMenu {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        contextMenuHighlight.hide()
+                        contextMenuHighlight.close()
                         contextMenuHighlight.annotation.color = color
                         highlightColorConfig.value = modelData
                     }
@@ -86,7 +87,7 @@ ContextMenu {
                 width: contextMenuHighlight.width / styles.model.length
                 height: parent.height
                 onClicked: {
-                    contextMenuHighlight.hide()
+                    contextMenuHighlight.close()
                     contextMenuHighlight.annotation.style = modelData["style"]
                     highlightStyleConfig.value = highlightStyleConfig.fromEnum(modelData["style"])
                 }

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -79,13 +79,6 @@ DocumentPage {
         }
     }
 
-    Loader {
-        parent: page
-        active: doc.failure || doc.locked
-        sourceComponent: placeholderComponent
-        anchors.verticalCenter: parent.verticalCenter
-    }
-
     Component {
         id: previewComponent
 
@@ -437,6 +430,13 @@ DocumentPage {
         }
     }
 
+    Loader {
+        parent: page
+        active: doc.failure || doc.locked
+        sourceComponent: placeholderComponent
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
     property Notification notice
 
     function noticeShow(message) {
@@ -486,7 +486,7 @@ DocumentPage {
             }
 
             Item {
-                visible:password.visible
+                visible: password.visible
                 width: 1
                 height: Theme.paddingLarge
             }


### PR DESCRIPTION
The Loader was behind the mostly invisible pdf view and thus not getting mouse events. Was not possible to move cursor, change password text visibility or tap the field to get focus back.

Also migrate from deprecated ContextMenu:hide() to close()

@dcaliste @llewelld @Tomin1 