### PR TITLE
[sailfish-office] Allow to store PDF passwords.

### DIFF
--- a/pdf/CMakeLists.txt
+++ b/pdf/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Poppler REQUIRED)
+find_package(Qt5Sql REQUIRED)
 
 include_directories(${POPPLER_INCLUDE_DIR} ${POPPLER_QT5_INCLUDE_DIR})
 
@@ -17,6 +18,7 @@ set(pdfplugin_SRCS
 
 add_library(sailfishofficepdfplugin MODULE ${pdfplugin_SRCS})
 qt5_use_modules(sailfishofficepdfplugin Quick)
+qt5_use_modules(sailfishofficepdfplugin Sql)
 target_link_libraries(sailfishofficepdfplugin stdc++ ${QT_LIBRARIES} ${POPPLER_LIBRARY} ${POPPLER_QT5_LIBRARY})
 
 install(TARGETS sailfishofficepdfplugin DESTINATION ${CMAKE_INSTALL_LIBDIR}/qt5/qml/Sailfish/Office/PDF)

--- a/pdf/pdfdocument.h
+++ b/pdf/pdfdocument.h
@@ -38,11 +38,13 @@ class PDFDocument : public QObject, public QQmlParserStatus
     Q_PROPERTY(int pageCount READ pageCount NOTIFY pageCountChanged)
     Q_PROPERTY(QObject* tocModel READ tocModel NOTIFY tocModelChanged)
     Q_PROPERTY(bool loaded READ isLoaded NOTIFY documentLoadedChanged)
+    Q_PROPERTY(bool passwordProtected READ isPasswordProtected NOTIFY documentLoadedChanged)
     Q_PROPERTY(bool failure READ isFailed NOTIFY documentFailedChanged)
     Q_PROPERTY(bool locked READ isLocked NOTIFY documentLockedChanged)
     Q_PROPERTY(bool modified READ isModified NOTIFY documentModifiedChanged)
     Q_PROPERTY(bool searching READ searching NOTIFY searchingChanged)
     Q_PROPERTY(QObject* searchModel READ searchModel NOTIFY searchModelChanged)
+    Q_PROPERTY(QString password READ password NOTIFY passwordChanged)
 
     Q_INTERFACES(QQmlParserStatus)
 
@@ -60,10 +62,12 @@ public:
     QObject* tocModel() const;
     bool searching() const;
     QObject* searchModel() const;
+    QString password() const;
     
     TextList textBoxesAtPage(int page);
 
     bool isLoaded() const;
+    bool isPasswordProtected() const;
     bool isFailed() const;
     bool isLocked() const;
     bool isModified() const;
@@ -75,6 +79,8 @@ public:
 
     void setDocumentModified();
 
+    Q_INVOKABLE void clearCachedPassword() const;
+
     int requestPage(int index, int size,
                      QRect subpart = QRect(), int extraData = 0);
 
@@ -84,7 +90,7 @@ public:
 public Q_SLOTS:
     void setSource(const QString &source);
     void setAutoSavePath(const QString &filename);
-    void requestUnLock(const QString &password);
+    void requestUnLock(const QString &password, bool store = false);
     void requestLinksAtPage(int page);
 
     void prioritizeRequest(int index, int size, QRect subpart = QRect());
@@ -105,6 +111,7 @@ Q_SIGNALS:
     void tocModelChanged();
     void searchingChanged();
     void searchModelChanged();
+    void passwordChanged();
     void pageModified(int index, const QRectF &subpart);
 
     void documentLoadedChanged();

--- a/pdf/pdfjob.cpp
+++ b/pdf/pdfjob.cpp
@@ -22,6 +22,11 @@
 #include <QUrlQuery>
 #include <poppler-qt5.h>
 
+#include <QStandardPaths>
+#include <QCryptographicHash>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QSqlError>
 #include <QElapsedTimer>
 #include <QLoggingCategory>
 
@@ -30,6 +35,11 @@ Q_LOGGING_CATEGORY(renderTimes, "org.sailfishos.office.pdf.timing", QtWarningMsg
 LoadDocumentJob::LoadDocumentJob(const QString &source)
     : PDFJob(PDFJob::LoadDocumentJob), m_source(source)
 {
+}
+
+QString LoadDocumentJob::source() const
+{
+    return m_source;
 }
 
 void LoadDocumentJob::run()
@@ -41,17 +51,150 @@ void LoadDocumentJob::run()
     }
 }
 
-UnLockDocumentJob::UnLockDocumentJob(const QString &password)
-    : PDFJob(PDFJob::UnLockDocumentJob), m_password(password)
+class DbWorker
 {
+public:
+    DbWorker(const QString &url);
+    ~DbWorker();
+
+    QByteArray load() const;
+    void clear() const;
+    void store(const QByteArray &password) const;
+
+private:
+    QString m_url;
+    QByteArray m_id;
+};
+
+static QByteArray md5(const QString &url)
+{
+    const QString path = QUrl(url).toLocalFile();
+    if (!path.isEmpty()) {
+        QFile f(path);
+        if (f.open(QFile::ReadOnly)) {
+            QCryptographicHash hash(QCryptographicHash::Md5);
+            hash.addData(&f);
+            return hash.result();
+        }
+    }
+    return QByteArray();
+}
+
+DbWorker::DbWorker(const QString &url)
+    : m_url(url), m_id(md5(url).toHex())
+{
+    if (!m_id.isEmpty() && !QSqlDatabase::contains()) {
+        QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
+        db.setDatabaseName(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                           + QString::fromLatin1("/pdf.db"));
+        if (!db.open()) {
+            qWarning() << "cannot open PDF database.";
+        }
+        QSqlQuery query(db);
+        /*
+          The Passwords table is used to associate a password to
+          a read-protected PDF document. A document is identified by
+          the md5 sum of its content, so the user can move documents.
+         */
+        if (!query.exec(QString::fromLatin1("CREATE TABLE IF NOT EXISTS Passwords(id TEXT, password TEXT)"))) {
+            qWarning() << "cannot create Passwords table";
+        }
+        if (!query.exec(QString::fromLatin1("CREATE UNIQUE INDEX IF NOT EXISTS PasswordsIndex on Passwords(id)"))) {
+            qWarning() << "cannot create Passwords index";
+        }
+    }
+}
+
+DbWorker::~DbWorker()
+{
+    QSqlDatabase db = QSqlDatabase::database();
+    if (db.isValid()) {
+        db.close();
+    }
+}
+
+QByteArray DbWorker::load() const
+{
+    QSqlDatabase db = QSqlDatabase::database();
+    if (!m_id.isEmpty() && db.isValid()) {
+        QSqlQuery query(db);
+        query.prepare(QString::fromLatin1("SELECT password FROM Passwords WHERE id = ?"));
+        query.addBindValue(m_id);
+        if (query.exec()) {
+            return query.next() ? query.value(0).toByteArray() : QByteArray();
+        } else {
+            qWarning() << "cannot get password for PDF document" << m_url;
+            qWarning() << "reason:" << query.lastError().text();
+        }
+    }
+    return QByteArray();
+}
+
+void DbWorker::clear() const
+{
+    QSqlDatabase db = QSqlDatabase::database();
+    if (!m_id.isEmpty() && db.isValid()) {
+        QSqlQuery query(db);
+        query.prepare(QString::fromLatin1("DELETE FROM Passwords WHERE id = ?"));
+        query.addBindValue(m_id);
+        query.exec();
+    }
+}
+
+void DbWorker::store(const QByteArray &password) const
+{
+    QSqlDatabase db = QSqlDatabase::database();
+    if (!m_id.isEmpty() && db.isValid()) {
+        QSqlQuery query(db);
+        query.prepare(QString::fromLatin1("INSERT OR REPLACE INTO Passwords(id, password) VALUES (?,?)"));
+        query.addBindValue(m_id);
+        query.addBindValue(password);
+        if (!query.exec()) {
+            qWarning() << "cannot set password for PDF document" << m_url;
+            qWarning() << "reason:" << query.lastError().text();
+        }
+    }
+}
+
+ClearSecretJob::ClearSecretJob(const QString &storeKey)
+    : PDFJob(PDFJob::ClearSecretJob), m_storeKey(storeKey)
+{
+}
+
+void ClearSecretJob::run()
+{
+    DbWorker db(m_storeKey);
+    db.clear();
+}
+
+UnLockDocumentJob::UnLockDocumentJob(const QString &password, const QString &storeKey)
+    : PDFJob(PDFJob::UnLockDocumentJob), m_password(password), m_storeKey(storeKey)
+{
+}
+
+QString UnLockDocumentJob::password() const
+{
+    return !m_storeKey.isEmpty() ? m_password : QString();
 }
 
 void UnLockDocumentJob::run()
 {
     Q_ASSERT(m_document);
 
-    if (m_document->isLocked())
+    if (m_document->isLocked()) {
+        const bool store = !m_password.isEmpty();
+        DbWorker secret(m_storeKey);
+        if (m_password.isEmpty()) {
+            m_password = QString::fromUtf8(secret.load());
+        }
         m_document->unlock(m_password.toUtf8(), m_password.toUtf8());
+        if (!m_document->isLocked() && store) {
+            secret.store(m_password.toUtf8());
+        } else if (m_document->isLocked()) {
+            secret.clear();
+            m_password.clear();
+        }
+    }
 }
 
 LinksJob::LinksJob(int page)

--- a/pdf/pdfjob.h
+++ b/pdf/pdfjob.h
@@ -35,6 +35,7 @@ class PDFJob : public QObject
 public:
     enum JobType {
         LoadDocumentJob,
+        ClearSecretJob,
         UnLockDocumentJob,
         LinksJob,
         RenderPageJob,
@@ -64,21 +65,36 @@ public:
     LoadDocumentJob(const QString &source);
 
     virtual void run();
+    QString source() const;
 
 private:
     QString m_source;
+};
+
+class ClearSecretJob : public PDFJob
+{
+    Q_OBJECT
+public:
+    ClearSecretJob(const QString &storeKey);
+
+    virtual void run(); // Default run action is clear().
+
+private:
+    QString m_storeKey;
 };
 
 class UnLockDocumentJob : public PDFJob
 {
     Q_OBJECT
 public:
-    UnLockDocumentJob(const QString &password);
+    UnLockDocumentJob(const QString &password, const QString &storeKey = QString());
 
     virtual void run();
+    QString password() const;
 
 private:
     QString m_password;
+    QString m_storeKey;
 };
 
 class LinksJob : public PDFJob

--- a/pdf/pdfrenderthread.h
+++ b/pdf/pdfrenderthread.h
@@ -40,6 +40,7 @@ public:
     int pageCount() const;
     QObject* tocModel() const;
     bool isLoaded() const;
+    bool isPasswordProtected() const;
     bool isFailed() const;
     bool isLocked() const;
     QMultiMap<int, QPair<QRectF, QUrl> > linkTargets() const;
@@ -53,6 +54,8 @@ public:
     void removeAnnotation(Poppler::Annotation *annotation, int pageIndex);
 
     void setAutoSaveName(const QString &filename);
+
+    QString cachedPassword() const;
 
     void queueJob(PDFJob *job);
     bool cancelRenderJob(int index);

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -36,6 +36,7 @@ install(FILES
     PDFContextMenuHighlight.qml
     PDFContextMenuLinks.qml
     PDFContextMenuText.qml
+    PDFDetailsPage.qml
     PDFDocumentPage.qml
     PDFDocumentToCPage.qml
     PDFSelectionDrag.qml
@@ -45,11 +46,14 @@ install(FILES
     PDFView.qml
     PlainTextDocumentPage.qml
     PresentationPage.qml
+    PresentationDetailsPage.qml
     PresentationThumbnailPage.qml
     SearchBarItem.qml
     ShareButton.qml
     SpreadsheetListPage.qml
     SpreadsheetPage.qml
+    SpreadsheetDetailsPage.qml
+    TextDetailsPage.qml
     TextDocumentPage.qml
     TextDocumentToCPage.qml
     ToolBar.qml

--- a/plugin/DetailsPage.qml
+++ b/plugin/DetailsPage.qml
@@ -24,9 +24,10 @@ import Nemo.FileManager 1.0
 Page {
     id: page
 
+    property QtObject document
     property url source
-    property int indexCount
     property string mimeType
+    default property alias children: contentColumn.data
 
     FileInfo {
         id: info
@@ -78,53 +79,6 @@ Page {
                 //% "Last modified"
                 label: qsTrId("sailfish-office-la-lastmodified")
                 value: Format.formatDate(info.lastModified, Format.DateFull)
-                alignment: Qt.AlignLeft
-            }
-
-            DetailItem {
-                label: {
-                    switch (page.mimeType) {
-                        case "application/vnd.oasis.opendocument.spreadsheet":
-                        case "application/x-kspread":
-                        case "application/vnd.ms-excel":
-                        case "text/csv":
-                        case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-                        case "application/vnd.openxmlformats-officedocument.spreadsheetml.template":
-                            //: Sheet count of the spreadsheet
-                            //% "Sheets"
-                            return qsTrId("sailfish-office-la-sheetcount")
-                        case "application/vnd.oasis.opendocument.presentation":
-                        case "application/vnd.oasis.opendocument.presentation-template":
-                        case "application/x-kpresenter":
-                        case "application/vnd.ms-powerpoint":
-                        case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-                        case "application/vnd.openxmlformats-officedocument.presentationml.template":
-                            //: Slide count detail of the presentation
-                            //% "Slides"
-                            return qsTrId("sailfish-office-la-slidecount")
-                        case "application/vnd.oasis.opendocument.text-master":
-                        case "application/vnd.oasis.opendocument.text":
-                        case "application/vnd.oasis.opendocument.text-template":
-                        case "application/msword":
-                        case "application/rtf":
-                        case "application/x-mswrite":
-                        case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-                        case "application/vnd.openxmlformats-officedocument.wordprocessingml.template":
-                        case "application/vnd.ms-works":
-                            //: Page count of the text document
-                            //% "Page Count"
-                            return qsTrId("sailfish-office-la-pagecount")
-                        case "application/pdf":
-                            //: Page count of the text document
-                            //% "Page Count"
-                            return qsTrId("sailfish-office-la-pagecount")
-                        default:
-                            //: Index count for unknown document types.
-                            //% "Index Count"
-                            return qsTrId("sailfish-office-la-indexcount")
-                    }
-                }
-                value: page.indexCount
                 alignment: Qt.AlignLeft
             }
         }

--- a/plugin/DocumentHeader.qml
+++ b/plugin/DocumentHeader.qml
@@ -20,14 +20,15 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 MouseArea {
+    property string detailsPage: "DetailsPage.qml"
     property int indexCount
     property DocumentPage page
     property color color: Theme.primaryColor
     readonly property bool down: pressed && containsMouse
 
-    onClicked: pageStack.animatorPush(Qt.resolvedUrl("DetailsPage.qml"), {
+    onClicked: pageStack.animatorPush(Qt.resolvedUrl(detailsPage), {
+                                          document: page.document,
                                           source: page.source,
-                                          indexCount: indexCount,
                                           mimeType: page.mimeType
                                       })
 

--- a/plugin/DocumentPage.qml
+++ b/plugin/DocumentPage.qml
@@ -27,6 +27,7 @@ Page {
     property bool error
     property string mimeType
     property alias busy: busyIndicator.running
+    property QtObject document
     property QtObject provider
     property Component preview: defaultPreview
     property alias placeholderPreview: defaultPreview

--- a/plugin/PDFDetailsPage.qml
+++ b/plugin/PDFDetailsPage.qml
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Damien Caliste
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Office 1.0
+
+DetailsPage {
+    readonly property bool storePassword: document.password.length > 0
+
+    DetailItem {
+        //: Page count of the PDF document
+        //% "Page Count"
+        label: qsTrId("sailfish-office-la-pdf-pagecount")
+        value: document.pageCount
+        alignment: Qt.AlignLeft
+        visible: !document.locked
+    }
+    SectionHeader {
+        visible: document.passwordProtected
+        //% "Read protection"
+        text: qsTrId("sailfish-office-la-pdf-readprotection")
+    }
+    Label {
+        visible: document.passwordProtected
+        width: parent.width - 2*x
+        x: Theme.horizontalPageMargin
+        //% "This document is protected by a password"
+        text: qsTrId("sailfish-office-la-pdf-passwordprotected")
+        color: palette.secondaryHighlightColor
+        font.pixelSize: Theme.fontSizeSmall
+        textFormat: Text.PlainText
+        wrapMode: Text.Wrap
+    }
+    Item {
+        visible: storePassword
+        width: parent.width
+        height: Theme.paddingLarge
+    }
+    PasswordField {
+        opacity: storePassword ? 1 : 0
+        Behavior on opacity {FadeAnimator {}}
+        x: Theme.horizontalPageMargin
+        width: parent.width - 2*x
+        text: document.password
+        readOnly: true
+    }
+    Item {
+        visible: storePassword
+        width: parent.width
+        height: Theme.paddingLarge
+    }
+    Button {
+        opacity: storePassword ? 1 : 0
+        Behavior on opacity {FadeAnimator {}}
+        anchors.horizontalCenter: parent.horizontalCenter
+        //% "Clear stored password"
+        text: qsTrId("sailfish-office-la-pdf-clearpassword")
+        onClicked: document.clearCachedPassword()
+    }
+}

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -38,6 +38,7 @@ DocumentPage {
     busy: (!doc.loaded && !doc.failure) || doc.searching
     error: doc.failure
     source: doc.source
+    document: doc
 
     preview: doc.loaded
             ? previewComponent
@@ -204,6 +205,7 @@ DocumentPage {
         DocumentHeader {
             id: header
             page: page
+            detailsPage: "PDFDetailsPage.qml"
             indexCount: doc.pageCount
             width: page.width
             x: view.contentX
@@ -501,7 +503,7 @@ DocumentPage {
                 EnterKey.iconSource: "image://theme/icon-m-enter-accept"
                 EnterKey.onClicked: {
                     focus = false
-                    doc.requestUnLock(text)
+                    doc.requestUnLock(text, storePassword.checked)
                     text = ""
                 }
 
@@ -509,6 +511,15 @@ DocumentPage {
                     if (visible)
                         forceActiveFocus()
                 }
+            }
+
+            TextSwitch {
+                id: storePassword
+                visible: doc.locked
+                x: Theme.horizontalPageMargin
+                width: parent.width - 2*x
+                //% "Remember password"
+                text: qsTrId("sailfish-office-lbl-remember-password")
             }
         }
     }

--- a/plugin/PresentationDetailsPage.qml
+++ b/plugin/PresentationDetailsPage.qml
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Damien Caliste
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Office 1.0
+
+DetailsPage {
+    DetailItem {
+        //: Slide count detail of the presentation
+        //% "Slides"
+        label: qsTrId("sailfish-office-la-slidecount")
+        value: document.indexCount
+        alignment: Qt.AlignLeft
+    }
+}

--- a/plugin/PresentationPage.qml
+++ b/plugin/PresentationPage.qml
@@ -127,9 +127,9 @@ CalligraDocumentPage {
 
         DocumentHeader {
             id: header
+            detailsPage: "PresentationDetailsPage.qml"
             color: Theme.lightPrimaryColor
             page: page
-            indexCount: page.document.indexCount
         }
 
         OverlayToolbar {

--- a/plugin/SpreadsheetDetailsPage.qml
+++ b/plugin/SpreadsheetDetailsPage.qml
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Damien Caliste
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Office 1.0
+
+DetailsPage {
+    DetailItem {
+        //: Sheet count of the spreadsheet
+        //% "Sheets"
+        label: qsTrId("sailfish-office-la-sheetcount")
+        value: document.indexCount
+        alignment: Qt.AlignLeft
+    }
+}

--- a/plugin/SpreadsheetPage.qml
+++ b/plugin/SpreadsheetPage.qml
@@ -105,9 +105,9 @@ CalligraDocumentPage {
 
         DocumentHeader {
             id: header
+            detailsPage: "SpreadsheetDetailsPage.qml"
             color: Theme.darkPrimaryColor
             page: page
-            indexCount: page.document.indexCount
         }
 
         OverlayToolbar {

--- a/plugin/TextDetailsPage.qml
+++ b/plugin/TextDetailsPage.qml
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Damien Caliste
+ * Contact: Damien Caliste <dcaliste@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Office 1.0
+
+DetailsPage {
+    DetailItem {
+        //: Page count of the text document
+        //% "Page Count"
+        label: qsTrId("sailfish-office-la-pagecount")
+        value: document.indexCount
+        alignment: Qt.AlignLeft
+    }
+}

--- a/plugin/TextDocumentPage.qml
+++ b/plugin/TextDocumentPage.qml
@@ -94,9 +94,9 @@ CalligraDocumentPage {
 
         DocumentHeader {
             id: header
+            detailsPage: "TextDetailsPage.qml"
             page: page
             width: page.width
-            indexCount: page.document.indexCount
             x: flickable.contentX
             y: -height
         }

--- a/rpm/sailfish-office.spec
+++ b/rpm/sailfish-office.spec
@@ -8,6 +8,7 @@ BuildRequires: pkgconfig(Qt5Quick)
 BuildRequires: pkgconfig(Qt5Widgets)
 #BuildRequires: pkgconfig(Qt5WebKit)
 BuildRequires: pkgconfig(Qt5DBus)
+BuildRequires: pkgconfig(Qt5Sql)
 BuildRequires: pkgconfig(sailfishsilica) >= 1.1.8
 BuildRequires: libqt5sparql-devel
 BuildRequires: poppler-qt5-devel poppler-qt5 poppler-devel poppler


### PR DESCRIPTION
@pvuorela I tried to implement via Sailfish Secret a manager for the passwords of protected PDF documents. You can decide to store the password you type, like that it is automatically applied on next opening. In the detail page of PDF documents, you can see the password that is saved for a given document and possibly remove the stored password if you don't want to keep it anymore.

The switch to allow to store the password in the placeholder asking for the password, makes the text field loose the focus, which is sub optimal. I've no idea how to treat this properly for the moment…