### PR TITLE
Adjust sparql to work with newer Tracker/Tinysparql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 Makefile
 moc_*
 mocs_*
+*.moc
 CMakeFiles

--- a/models/documentlistmodel.h
+++ b/models/documentlistmodel.h
@@ -39,8 +39,7 @@ public:
     };
     Q_ENUMS(DocumentClass)
 
-    enum Roles
-    {
+    enum Roles {
         FileNameRole = Qt::UserRole + 1,
         FilePathRole,
         FileTypeRole,

--- a/models/trackerdocumentprovider.cpp
+++ b/models/trackerdocumentprovider.cpp
@@ -39,14 +39,15 @@ static const QString documentQuery{
     "SELECT ?name ?path ?size ?lastModified ?mimeType "
     "WHERE {"
     "  GRAPH tracker:Documents {"
-    "    SELECT nfo:fileName(?path) AS ?name"
-    "      nfo:fileSize(?path) AS ?size"
-    "      nfo:fileLastModified(?path) AS ?lastModified"
-    "      ?path ?mimeType"
+    "    SELECT nfo:fileName(?path1) AS ?name"
+    "      nfo:fileSize(?path1) AS ?size"
+    "      nfo:fileLastModified(?path1) AS ?lastModified"
+    "      ?path1 AS ?path "
+    "      ?mimeType1 AS ?mimeType"
     "    WHERE {"
-    "      ?u nie:isStoredAs ?path ."
-    "      ?path nie:dataSource/tracker:available true . "
-    "      ?u nie:mimeType ?mimeType ."
+    "      ?u nie:isStoredAs ?path1 ."
+    "      ?path1 nie:dataSource/tracker:available true . "
+    "      ?u nie:mimeType ?mimeType1 ."
     "      { ?u a nfo:PaginatedTextDocument . }"
     "      UNION { ?u nie:mimeType 'text/plain' FILTER(fn:ends-with(nfo:fileName(nie:isStoredAs(?u)),'.txt')) }"
     "    }"
@@ -67,7 +68,8 @@ public:
         model->setObjectName("TrackerDocumentList");
     }
 
-    ~Private() {
+    ~Private()
+    {
         model->deleteLater();
     }
 

--- a/plugin/CalligraDocumentPage.qml
+++ b/plugin/CalligraDocumentPage.qml
@@ -50,6 +50,7 @@ DocumentPage {
 
     Timer {
         id: previewDelay
+
         interval: 100
         running: doc.status === Calligra.DocumentStatus.Loaded
         // We're not using a binding for the preview because calligra is sensitive to the order

--- a/plugin/ContextMenuHook.qml
+++ b/plugin/ContextMenuHook.qml
@@ -81,7 +81,7 @@ Item {
     }
 
     width: _menu && _menu._flickable ? _menu._flickable.width : 0
-    x:  _menu && _menu._flickable ? _menu._flickable.contentX : 0
+    x: _menu && _menu._flickable ? _menu._flickable.contentX : 0
     height: _hookHeight + (_menu ? Theme.paddingSmall + _menu.height : 0.)
 
     Rectangle {

--- a/plugin/ControllerFlickable.qml
+++ b/plugin/ControllerFlickable.qml
@@ -74,6 +74,7 @@ DocumentFlickable {
         }
         NumberAnimation {
             id: zoomOutContentYAnimation
+
             target: flickable
             properties: "contentY"
             easing.type: Easing.InOutQuad

--- a/plugin/DetailsPage.qml
+++ b/plugin/DetailsPage.qml
@@ -46,7 +46,6 @@ Page {
             width: parent.width
 
             PageHeader {
-                id: detailsHeader
                 //: Details page title
                 //% "Details"
                 title: qsTrId("sailfish-office-he-details")

--- a/plugin/PDFAnnotationEdit.qml
+++ b/plugin/PDFAnnotationEdit.qml
@@ -50,6 +50,7 @@ Page {
             width: parent.width
             PageHeader {
                 id: pageHeader
+
                 title: annotation && annotation.author != ""
                        ? annotation.author
                        : (_isText

--- a/plugin/PDFDocumentPage.qml
+++ b/plugin/PDFDocumentPage.qml
@@ -394,6 +394,7 @@ DocumentPage {
 
         IndexButton {
             id: indexButton
+
             onClicked: {
                 toolbar.toggle(indexButton)
                 var obj = pageStack.animatorPush(Qt.resolvedUrl("PDFDocumentToCPage.qml"),
@@ -530,11 +531,13 @@ DocumentPage {
     }
     ConfigurationValue {
         id: highlightColorConfig
+
         key: "/apps/sailfish-office/settings/highlightColor"
         defaultValue: "#ffff00"
     }
     ConfigurationValue {
         id: highlightStyleConfig
+
         key: "/apps/sailfish-office/settings/highlightStyle"
         defaultValue: "highlight"
 

--- a/plugin/PDFDocumentToCPage.qml
+++ b/plugin/PDFDocumentToCPage.qml
@@ -73,6 +73,7 @@ Page {
             }
             Label {
                 id: pageNumberLabel
+
                 anchors {
                     right: parent.right
                     rightMargin: Theme.horizontalPageMargin

--- a/plugin/PDFSelectionView.qml
+++ b/plugin/PDFSelectionView.qml
@@ -41,6 +41,7 @@ Repeater {
     children: [
         PDFSelectionHandle {
             id: handle1
+
             visible: root.draggable
             attachX: root.flickable !== undefined
                      ? flickable.contentX
@@ -50,6 +51,7 @@ Repeater {
         },
         PDFSelectionHandle {
             id: handle2
+
             visible: root.draggable
             attachX: root.flickable !== undefined
                      ? flickable.contentX + flickable.width

--- a/plugin/PDFView.qml
+++ b/plugin/PDFView.qml
@@ -540,6 +540,7 @@ DocumentFlickable {
         }
         NumberAnimation {
             id: zoomOutContentYAnimation
+
             target: root
             properties: "contentY"
             easing.type: Easing.InOutQuad

--- a/plugin/PlainTextDocumentPage.qml
+++ b/plugin/PlainTextDocumentPage.qml
@@ -51,7 +51,9 @@ DocumentPage {
             ListView {
                 id: previewView
 
-                Component.onCompleted: positionViewAtIndex(Math.max(0, documentView.indexAt(0, documentView.contentY)), ListView.Beginning)
+                Component.onCompleted: positionViewAtIndex(Math.max(0,
+                                                                    documentView.indexAt(0, documentView.contentY)),
+                                                           ListView.Beginning)
 
                 anchors.fill: parent
                 model: documentModel
@@ -109,7 +111,9 @@ DocumentPage {
             width: horizontalFlickable.contentWidth
             height: documentPage.height
 
-            _quickScrollItem.rightMargin: horizontalFlickable.contentWidth - horizontalFlickable.width - horizontalFlickable.contentX
+            _quickScrollItem.rightMargin: horizontalFlickable.contentWidth
+                                          - horizontalFlickable.width
+                                          - horizontalFlickable.contentX
 
             model: PlainTextModel {
                 id: documentModel
@@ -151,7 +155,8 @@ DocumentPage {
 
             ViewPlaceholder {
                 enabled: documentModel.lineCount === 0
-                         && (documentModel.status === PlainTextModel.Ready || documentModel.status === PlainTextModel.Error)
+                         && (documentModel.status === PlainTextModel.Ready
+                             || documentModel.status === PlainTextModel.Error)
                 text: documentModel.status === PlainTextModel.Error
                         //% "Error loading text file"
                         ? qsTrId("sailfish-office-la-plain_text_error")
@@ -161,7 +166,9 @@ DocumentPage {
 
             VerticalScrollDecorator {
                 color: Theme.highlightDimmerColor
-                anchors.rightMargin: horizontalFlickable.contentWidth - horizontalFlickable.width - horizontalFlickable.contentX
+                anchors.rightMargin: horizontalFlickable.contentWidth
+                                     - horizontalFlickable.width
+                                     - horizontalFlickable.contentX
             }
 
         }

--- a/plugin/PresentationPage.qml
+++ b/plugin/PresentationPage.qml
@@ -104,6 +104,7 @@ CalligraDocumentPage {
             }
             Calligra.ImageDataItem {
                 id: largeThumb
+
                 visible: implicitWidth > 0
                 anchors.fill: parent
             }
@@ -112,6 +113,7 @@ CalligraDocumentPage {
 
     Item {
         id: overlay
+
         property bool active: true
 
         enabled: active
@@ -127,6 +129,7 @@ CalligraDocumentPage {
 
         DocumentHeader {
             id: header
+
             detailsPage: "PresentationDetailsPage.qml"
             color: Theme.lightPrimaryColor
             page: page

--- a/plugin/PresentationThumbnailPage.qml
+++ b/plugin/PresentationThumbnailPage.qml
@@ -71,6 +71,7 @@ Page {
 
                 Label {
                     id: label
+
                     anchors.centerIn: parent
                     text: model.contentIndex + 1
                     color: Theme.lightPrimaryColor
@@ -78,7 +79,8 @@ Page {
 
                 Rectangle {
                     anchors.fill: parent
-                    color: mouseArea.pressed && mouseArea.containsMouse ? Theme.highlightBackgroundColor : "transparent"
+                    color: mouseArea.pressed && mouseArea.containsMouse ? Theme.highlightBackgroundColor
+                                                                        : "transparent"
                     opacity: Theme.highlightBackgroundOpacity
                 }
 
@@ -86,6 +88,7 @@ Page {
 
             MouseArea {
                 id: mouseArea
+
                 anchors.fill: parent
                 onClicked: {
                     page.document.currentIndex = model.contentIndex

--- a/plugin/ShareButton.qml
+++ b/plugin/ShareButton.qml
@@ -22,6 +22,7 @@ import Sailfish.Share 1.0
 
 IconButton {
     property DocumentPage page
+
     icon.source: "image://theme/icon-m-share"
     visible: page.source != ""  && !page.error
     anchors.verticalCenter: parent.verticalCenter

--- a/plugin/SpreadsheetPage.qml
+++ b/plugin/SpreadsheetPage.qml
@@ -65,6 +65,7 @@ CalligraDocumentPage {
 
         Calligra.ViewController {
             id: viewController
+
             view: documentView
             flickable: flickable
             useZoomProxy: false
@@ -89,6 +90,7 @@ CalligraDocumentPage {
 
     Item {
         id: overlay
+
         property bool active: true
 
         enabled: active
@@ -105,6 +107,7 @@ CalligraDocumentPage {
 
         DocumentHeader {
             id: header
+
             detailsPage: "SpreadsheetDetailsPage.qml"
             color: Theme.darkPrimaryColor
             page: page

--- a/plugin/TextDocumentPage.qml
+++ b/plugin/TextDocumentPage.qml
@@ -121,7 +121,8 @@ CalligraDocumentPage {
         }
 
         IndexButton {
-            onClicked: pageStack.animatorPush(Qt.resolvedUrl("TextDocumentToCPage.qml"), { document: page.document, contents: page.contents })
+            onClicked: pageStack.animatorPush(Qt.resolvedUrl("TextDocumentToCPage.qml"),
+                                              { document: page.document, contents: page.contents })
 
             index: Math.max(1, page.document.currentIndex)
             count: page.document.indexCount

--- a/plugin/TextDocumentToCPage.qml
+++ b/plugin/TextDocumentToCPage.qml
@@ -30,6 +30,7 @@ Page {
 
     SilicaListView {
         id: view
+
         anchors.fill: parent
 
         //: Page with Text document index
@@ -38,6 +39,7 @@ Page {
 
         delegate: BackgroundItem {
             property bool isCurrentItem: model.contentIndex + 1 == page.document.currentIndex
+
             Label {
                 x: Theme.horizontalPageMargin
                 width: parent.width - 2*x

--- a/plugin/ToolBar.qml
+++ b/plugin/ToolBar.qml
@@ -100,6 +100,7 @@ PanelBackground {
 
     Timer {
         id: autoHideTimer
+
         interval: 4000
         onTriggered: _active = false
     }

--- a/qml/FileListPage.qml
+++ b/qml/FileListPage.qml
@@ -109,6 +109,7 @@ Page {
 
             PageHeader {
                 id: pageHeader
+
                 //: Application title
                 //% "Documents"
                 title: qsTrId("sailfish-office-he-apptitle")
@@ -292,6 +293,7 @@ Page {
             menu: Component {
                 ContextMenu {
                     id: contextMenu
+
                     MenuItem {
                         //: Share a file
                         //% "Share"


### PR DESCRIPTION
Main commit:

    [sailfish-office] Adjust sparql to work with newer Tracker/Tinysparql. JB#61614
    
    Depending on details, newer versions of Tinysparql (formerly known
    as Tracker) might choke on nested SELECTs with same ids.
    See https://gitlab.gnome.org/GNOME/tinysparql/-/issues/472
    
    Unclear whether those should work or not but let's now just avoid
